### PR TITLE
[codex] Complete M2 primary-source surfaces

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,11 +3,17 @@ from functools import lru_cache
 from typing import List, Optional
 
 from pydantic import AnyHttpUrl, Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Centralized configuration loaded from env vars or `.env`."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+    )
 
     project_name: str = "Congresscape API"
     api_v1_prefix: str = "/api/v1"
@@ -31,11 +37,6 @@ class Settings(BaseSettings):
 
     # Feature flags
     enable_realtime: bool = False
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = False
 
 
 @lru_cache

--- a/backend/app/schemas/legislative.py
+++ b/backend/app/schemas/legislative.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 
 SourceConfidence = Literal["direct_source", "related_entity", "topic_context", "unavailable"]
@@ -24,11 +24,9 @@ class LegislativeSourceLinkBase(BaseModel):
 
 
 class LegislativeSourceLinkRead(LegislativeSourceLinkBase):
-    id: int
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
-    class Config:
-        from_attributes = True
-        populate_by_name = True
+    id: int
 
 
 class CongressionalCommitteeBase(BaseModel):
@@ -43,12 +41,10 @@ class CongressionalCommitteeBase(BaseModel):
 
 
 class CongressionalCommitteeRead(CongressionalCommitteeBase):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
     id: int
     source_links: list[LegislativeSourceLinkRead] = Field(default_factory=list)
-
-    class Config:
-        from_attributes = True
-        populate_by_name = True
 
 
 class BillActionBase(BaseModel):
@@ -65,13 +61,11 @@ class BillActionBase(BaseModel):
 
 
 class BillActionRead(BillActionBase):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
     id: int
     bill_id: int
     source_links: list[LegislativeSourceLinkRead] = Field(default_factory=list)
-
-    class Config:
-        from_attributes = True
-        populate_by_name = True
 
 
 class BillTextVersionBase(BaseModel):
@@ -85,13 +79,11 @@ class BillTextVersionBase(BaseModel):
 
 
 class BillTextVersionRead(BillTextVersionBase):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
     id: int
     bill_id: int
     source_links: list[LegislativeSourceLinkRead] = Field(default_factory=list)
-
-    class Config:
-        from_attributes = True
-        populate_by_name = True
 
 
 class CongressionalBillBase(BaseModel):
@@ -118,18 +110,18 @@ class CongressionalBillBase(BaseModel):
 
 
 class CongressionalBillRead(CongressionalBillBase):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
     id: int
     actions: list[BillActionRead] = Field(default_factory=list)
     text_versions: list[BillTextVersionRead] = Field(default_factory=list)
     committees: list[CongressionalCommitteeRead] = Field(default_factory=list)
     source_links: list[LegislativeSourceLinkRead] = Field(default_factory=list)
 
-    class Config:
-        from_attributes = True
-        populate_by_name = True
-
 
 class CongressionalMemberRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     bioguide_id: str
     name: str
@@ -142,11 +134,10 @@ class CongressionalMemberRead(BaseModel):
     congress_url: HttpUrl | None = None
     identifiers: dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        from_attributes = True
-
 
 class CongressionalVoteRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     canonical_id: str
     chamber: str
@@ -161,11 +152,10 @@ class CongressionalVoteRead(BaseModel):
     totals: dict[str, Any] = Field(default_factory=dict)
     party_split: dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        from_attributes = True
-
 
 class CongressionalHearingRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     canonical_id: str
     event_id: str
@@ -182,9 +172,6 @@ class CongressionalHearingRead(BaseModel):
     related_bills: list[dict[str, Any]] = Field(default_factory=list)
     videos: list[dict[str, Any]] = Field(default_factory=list)
     transcripts: list[dict[str, Any]] = Field(default_factory=list)
-
-    class Config:
-        from_attributes = True
 
 
 class DistrictLookupResponse(BaseModel):

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PushTokenCreate(BaseModel):
@@ -17,11 +17,10 @@ class PushTokenCreate(BaseModel):
 class PushTokenRead(BaseModel):
     """Echo back the stored token with metadata."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     token: str
     platform: str
     timezone: str | None = None
     created_at: datetime
-
-    class Config:
-        from_attributes = True

--- a/backend/app/schemas/update.py
+++ b/backend/app/schemas/update.py
@@ -1,8 +1,8 @@
 """Pydantic schemas for API requests/responses."""
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from app.models.update import BranchEnum
 
@@ -14,10 +14,9 @@ class EntityBase(BaseModel):
 
 
 class EntityRead(EntityBase):
-    id: int
+    model_config = ConfigDict(from_attributes=True)
 
-    class Config:
-        from_attributes = True
+    id: int
 
 
 class GovernmentUpdateBase(BaseModel):
@@ -44,12 +43,23 @@ class GovernmentUpdateCreate(GovernmentUpdateBase):
 
 
 class GovernmentUpdateRead(GovernmentUpdateBase):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
     id: int
     entities: List[EntityRead] = []
 
-    class Config:
-        from_attributes = True
-        populate_by_name = True
+
+class FeedItemRead(GovernmentUpdateRead):
+    """Frontend-ready feed item enriched for primary-source civic surfaces."""
+
+    card_type: str
+    rank_context: dict[str, Any] = Field(default_factory=dict)
+    involved: list[dict[str, Any]] = Field(default_factory=list)
+    key_claims: list[dict[str, Any]] = Field(default_factory=list)
+    source_trail: list[dict[str, Any]] = Field(default_factory=list)
+    source_trail_status: str = "available"
+    source_trail_note: str | None = None
+    detail: dict[str, Any] = Field(default_factory=dict)
 
 
 class FeedQueryParams(BaseModel):
@@ -59,10 +69,17 @@ class FeedQueryParams(BaseModel):
     search: Optional[str] = None
     start_date: Optional[datetime] = None
     end_date: Optional[datetime] = None
+    sort: Optional[str] = None
+    card_type: Optional[str] = None
+    followed_bills: Optional[str] = None
+    followed_members: Optional[str] = None
+    followed_topics: Optional[str] = None
+    state: Optional[str] = None
+    district: Optional[str] = None
     limit: int = 20
     offset: int = 0
 
 
 class FeedResponse(BaseModel):
-    items: List[GovernmentUpdateRead]
+    items: List[FeedItemRead]
     total: int

--- a/backend/app/services/feed_service.py
+++ b/backend/app/services/feed_service.py
@@ -1,12 +1,25 @@
-"""Feed querying and personalization logic."""
-from typing import List
+"""Feed querying and primary-source civic card assembly."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, List
 
 from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.legislative import (
+    BillAction,
+    BillTextVersion,
+    CongressionalBill,
+    CongressionalCommittee,
+    CongressionalHearing,
+    CongressionalVote,
+    LegislativeSourceLink,
+    MemberVotePosition,
+)
 from app.models.update import GovernmentUpdate
 from app.schemas.update import FeedQueryParams
-from app.services.personalization import rank_updates
+from app.services.personalization import rank_updates, ranking_factors
 
 
 class FeedService:
@@ -35,13 +48,443 @@ class FeedService:
             query = query.where(GovernmentUpdate.published_at <= params.end_date)
         return query
 
-    async def list_updates(self, params: FeedQueryParams) -> tuple[List[GovernmentUpdate], int]:
+    async def list_updates(self, params: FeedQueryParams) -> tuple[List[dict[str, Any]], int]:
         query = self._apply_filters(self._base_query(), params)
 
-        total_stmt = select(func.count()).select_from(query.subquery())
-        total_result = await self.session.execute(total_stmt)
-        total = total_result.scalar_one()
+        result = await self.session.execute(query)
+        ranked = rank_updates(result.scalars().all(), context=self._ranking_context(params))
+        feed_items = [self._to_feed_item(update, params) for update in ranked]
 
-        result = await self.session.execute(query.offset(params.offset).limit(params.limit))
-        items = rank_updates(result.scalars().all(), context={"params": params.model_dump(exclude_none=True)})
-        return items, total
+        if params.card_type:
+            feed_items = [item for item in feed_items if item["card_type"] == params.card_type]
+
+        total = len(feed_items)
+        return feed_items[params.offset : params.offset + params.limit], total
+
+    def _ranking_context(self, params: FeedQueryParams) -> dict[str, Any]:
+        return params.model_dump(exclude_none=True)
+
+    def _to_feed_item(self, update: GovernmentUpdate, params: FeedQueryParams) -> dict[str, Any]:
+        metadata = update.metadata_json or {}
+        card_type = self._card_type(update, metadata)
+        source_trail = self._source_trail(update)
+        source_trail_status = "available" if source_trail else "pending"
+        source_trail_note = None if source_trail else "Official source link has not been published for this event yet."
+
+        return {
+            "id": update.id,
+            "external_id": update.external_id,
+            "source": update.source,
+            "branch": update.branch,
+            "headline": update.headline,
+            "summary": update.summary,
+            "full_text": update.full_text,
+            "published_at": update.published_at,
+            "event_date": update.event_date,
+            "url": update.url,
+            "bill_id": update.bill_id,
+            "bill_action_id": update.bill_action_id,
+            "vote_id": update.vote_id,
+            "hearing_id": update.hearing_id,
+            "tags": update.tags or [],
+            "metadata": metadata,
+            "entities": [
+                {"id": entity.id, "name": entity.name, "type": entity.type, "slug": entity.slug}
+                for entity in update.entities
+            ],
+            "card_type": card_type,
+            "rank_context": self._rank_context(update, params, metadata),
+            "involved": self._involved(update),
+            "key_claims": self._key_claims(update, bool(source_trail)),
+            "source_trail": source_trail,
+            "source_trail_status": source_trail_status,
+            "source_trail_note": source_trail_note,
+            "detail": self._detail(update, params, card_type),
+        }
+
+    def _card_type(self, update: GovernmentUpdate, metadata: dict[str, Any]) -> str:
+        metadata_type = metadata.get("card_type") or metadata.get("event_type")
+        if isinstance(metadata_type, str) and metadata_type in {"bill", "vote", "hearing", "money", "alert"}:
+            return metadata_type
+        if update.vote_id:
+            return "vote"
+        if update.hearing_id:
+            return "hearing"
+        if update.bill_id or update.bill_action_id:
+            return "bill"
+        tags = {str(tag).lower() for tag in (update.tags or [])}
+        if "vote" in tags:
+            return "vote"
+        if "hearing" in tags:
+            return "hearing"
+        return "bill" if "bill" in tags or "legislation" in tags else "alert"
+
+    def _rank_context(self, update: GovernmentUpdate, params: FeedQueryParams, metadata: dict[str, Any]) -> dict[str, Any]:
+        factors = ranking_factors(update, context=self._ranking_context(params))
+        reasons: list[str] = []
+        if update.vote_id:
+            reasons.append("Roll-call votes are high-importance primary-source events.")
+        if update.hearing_id:
+            reasons.append("Hearings are ranked for schedule and oversight relevance.")
+        if update.bill_action_id:
+            reasons.append("Bill lifecycle actions are ranked by official action importance.")
+        if params.followed_bills or params.followed_members or params.followed_topics:
+            reasons.append("Followed bills, members, and topics raise relevant cards when they match.")
+        if params.state or params.district:
+            reasons.append("District and state context raise local representative activity when present.")
+        if update.url or metadata.get("source_trail"):
+            reasons.append("Official source links are available on the card.")
+
+        return {
+            "score": sum(factors.values()),
+            "factors": factors,
+            "reasons": reasons,
+        }
+
+    def _source_trail(self, update: GovernmentUpdate) -> list[dict[str, Any]]:
+        metadata = update.metadata_json or {}
+        metadata_trail = metadata.get("source_trail")
+        if isinstance(metadata_trail, list) and metadata_trail:
+            return [dict(item) for item in metadata_trail if isinstance(item, dict)]
+
+        links: list[dict[str, Any]] = []
+        for source_link in self._related_source_links(update):
+            links.append(self._source_link_dict(source_link))
+
+        if update.url and not any(link.get("url") == update.url for link in links):
+            links.insert(
+                0,
+                {
+                    "label": "Official source",
+                    "source": update.source,
+                    "url": update.url,
+                    "published_at": _iso(update.published_at),
+                    "retrieved_at": None,
+                    "supports": ["headline", "summary"],
+                },
+            )
+        return links
+
+    def _related_source_links(self, update: GovernmentUpdate) -> list[LegislativeSourceLink]:
+        links: list[LegislativeSourceLink] = []
+        if update.bill:
+            links.extend(update.bill.source_links)
+        if update.bill_action:
+            links.extend(update.bill_action.source_links)
+        if update.vote:
+            links.extend(update.vote.source_links)
+        if update.hearing:
+            links.extend(update.hearing.source_links)
+
+        seen: set[tuple[str, str]] = set()
+        deduped: list[LegislativeSourceLink] = []
+        for link in links:
+            key = (link.source_system, link.url)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(link)
+        return deduped
+
+    def _source_link_dict(self, link: LegislativeSourceLink) -> dict[str, Any]:
+        return {
+            "label": link.label,
+            "source": link.source_system,
+            "url": link.url,
+            "published_at": _iso(link.published_at),
+            "retrieved_at": _iso(link.retrieved_at),
+            "supports": link.supports or [],
+            "confidence": link.confidence,
+            "source_category": link.source_category,
+        }
+
+    def _involved(self, update: GovernmentUpdate) -> list[dict[str, Any]]:
+        involved = [
+            {"name": entity.name, "entity_type": entity.type, "role": None, "identifier": entity.slug, "url": None}
+            for entity in update.entities
+        ]
+        if update.bill:
+            involved.append(
+                {
+                    "name": update.bill.short_title or update.bill.title,
+                    "entity_type": "bill",
+                    "role": "subject",
+                    "identifier": update.bill.canonical_id,
+                    "url": update.bill.congress_url,
+                }
+            )
+            for committee in update.bill.committees:
+                involved.append(self._committee_involved(committee, "committee"))
+        if update.vote:
+            involved.append(
+                {
+                    "name": f"{update.vote.chamber} roll call {update.vote.roll_number}",
+                    "entity_type": "vote",
+                    "role": "roll_call",
+                    "identifier": update.vote.canonical_id,
+                    "url": update.vote.source_url,
+                }
+            )
+        if update.hearing:
+            involved.append(
+                {
+                    "name": update.hearing.title,
+                    "entity_type": "hearing",
+                    "role": "committee_activity",
+                    "identifier": update.hearing.canonical_id,
+                    "url": update.hearing.source_url,
+                }
+            )
+            if update.hearing.committee:
+                involved.append(self._committee_involved(update.hearing.committee, "host_committee"))
+        return involved
+
+    def _committee_involved(self, committee: CongressionalCommittee, role: str) -> dict[str, Any]:
+        return {
+            "name": committee.name,
+            "entity_type": "committee",
+            "role": role,
+            "identifier": committee.committee_code,
+            "url": committee.congress_url,
+        }
+
+    def _key_claims(self, update: GovernmentUpdate, has_source: bool) -> list[dict[str, Any]]:
+        source_indexes = [0] if has_source else []
+        unavailable_reason = None if has_source else "Official source link has not been attached yet."
+        claims = [
+            {
+                "id": "headline",
+                "text": update.headline,
+                "source_indexes": source_indexes,
+                "unavailable_reason": unavailable_reason,
+            }
+        ]
+        if update.summary:
+            claims.append(
+                {
+                    "id": "summary",
+                    "text": update.summary,
+                    "source_indexes": source_indexes,
+                    "unavailable_reason": unavailable_reason,
+                }
+            )
+        return claims
+
+    def _detail(self, update: GovernmentUpdate, params: FeedQueryParams, card_type: str) -> dict[str, Any]:
+        if card_type == "vote" and update.vote:
+            return {"vote": self._vote_detail(update.vote, params)}
+        if card_type == "hearing" and update.hearing:
+            return {"hearing": self._hearing_detail(update.hearing)}
+        if update.bill:
+            return {"bill": self._bill_detail(update.bill, update)}
+        return {}
+
+    def _bill_detail(self, bill: CongressionalBill, update: GovernmentUpdate) -> dict[str, Any]:
+        timeline = sorted(bill.actions, key=lambda action: _sortable_datetime(action.acted_at), reverse=True)
+        text_versions = sorted(
+            bill.text_versions,
+            key=lambda text_version: _sortable_datetime(text_version.published_at),
+            reverse=True,
+        )
+        eligible_vote = bool(bill.votes) or bool((update.metadata_json or {}).get("vote_eligible"))
+
+        return {
+            "canonical_id": bill.canonical_id,
+            "display_number": f"{bill.bill_type.upper()} {bill.number}",
+            "title": bill.title,
+            "short_title": bill.short_title,
+            "status": bill.latest_action_text or "Official lifecycle status has not been published yet.",
+            "origin_chamber": bill.origin_chamber,
+            "policy_area": bill.policy_area,
+            "introduced_at": _iso(bill.introduced_at),
+            "latest_action_at": _iso(bill.latest_action_at),
+            "sponsors": _list_or_unavailable((bill.metadata_json or {}).get("sponsors")),
+            "cosponsors": _list_or_unavailable(bill.cosponsors),
+            "committees": [self._committee_detail(committee) for committee in bill.committees],
+            "timeline": [self._action_detail(action) for action in timeline],
+            "text_versions": [self._text_version_detail(text_version) for text_version in text_versions],
+            "amendments": _list_or_unavailable(bill.amendments),
+            "related_bills": _list_or_unavailable(bill.related_bills),
+            "cbo_cost_estimates": _list_or_unavailable(bill.cbo_cost_estimates),
+            "crs_reports": _list_or_unavailable(bill.crs_reports),
+            "votes": [self._vote_summary(vote) for vote in bill.votes],
+            "vote_eligible": eligible_vote,
+            "user_position_prompt": (
+                "Record a personal position for comparison. This is civic tracking, not an official congressional vote."
+                if eligible_vote
+                else None
+            ),
+            "source_url": bill.congress_url,
+            "unavailable": {
+                "committees": "No committee referrals are published yet." if not bill.committees else None,
+                "text_versions": "No official bill text versions are published yet." if not bill.text_versions else None,
+                "votes": "No roll-call vote is linked to this bill yet." if not bill.votes else None,
+            },
+        }
+
+    def _vote_detail(self, vote: CongressionalVote, params: FeedQueryParams) -> dict[str, Any]:
+        positions = [self._position_detail(position) for position in vote.positions]
+        local_positions = [
+            position
+            for position in positions
+            if _matches_local_context(position, params.state, params.district)
+        ]
+
+        return {
+            "canonical_id": vote.canonical_id,
+            "chamber": vote.chamber,
+            "congress": vote.congress,
+            "session": vote.session,
+            "roll_number": vote.roll_number,
+            "vote_date": _iso(vote.vote_date),
+            "question": vote.question,
+            "result": vote.result,
+            "margin": _vote_margin(vote.totals),
+            "totals": vote.totals or {},
+            "party_split": vote.party_split or {},
+            "positions": sorted(positions, key=lambda item: (item.get("state") or "", item["member_name"])),
+            "local_representative_positions": local_positions,
+            "linked_bill": self._bill_summary(vote.bill) if vote.bill else None,
+            "source_url": vote.source_url,
+            "unavailable": {
+                "member_positions": "Official member vote positions have not been published yet." if not positions else None,
+                "local_representatives": (
+                    "No local representative match was available for this vote."
+                    if (params.state or params.district) and not local_positions
+                    else None
+                ),
+            },
+        }
+
+    def _hearing_detail(self, hearing: CongressionalHearing) -> dict[str, Any]:
+        committee = self._committee_detail(hearing.committee) if hearing.committee else None
+        return {
+            "canonical_id": hearing.canonical_id,
+            "event_id": hearing.event_id,
+            "congress": hearing.congress,
+            "chamber": hearing.chamber,
+            "title": hearing.title,
+            "meeting_type": hearing.meeting_type,
+            "status": hearing.status,
+            "scheduled_at": _iso(hearing.scheduled_at),
+            "location": hearing.location,
+            "committee": committee,
+            "witnesses": _list_or_unavailable(hearing.witnesses),
+            "related_bills": _list_or_unavailable(hearing.related_bills),
+            "videos": _list_or_unavailable(hearing.videos),
+            "transcripts": _list_or_unavailable(hearing.transcripts),
+            "source_url": hearing.source_url,
+            "follow_supported": bool(committee),
+            "alert_affordance": "Follow this committee for hearing alerts." if committee else None,
+            "unavailable": {
+                "witnesses": "Official witness details are not published yet." if not hearing.witnesses else None,
+                "videos": "Official video is not published yet." if not hearing.videos else None,
+                "transcripts": "Official transcript is not published yet." if not hearing.transcripts else None,
+            },
+        }
+
+    def _bill_summary(self, bill: CongressionalBill) -> dict[str, Any]:
+        return {
+            "id": bill.id,
+            "canonical_id": bill.canonical_id,
+            "display_number": f"{bill.bill_type.upper()} {bill.number}",
+            "title": bill.short_title or bill.title,
+            "source_url": bill.congress_url,
+        }
+
+    def _vote_summary(self, vote: CongressionalVote) -> dict[str, Any]:
+        return {
+            "id": vote.id,
+            "canonical_id": vote.canonical_id,
+            "chamber": vote.chamber,
+            "roll_number": vote.roll_number,
+            "vote_date": _iso(vote.vote_date),
+            "question": vote.question,
+            "result": vote.result,
+            "source_url": vote.source_url,
+        }
+
+    def _committee_detail(self, committee: CongressionalCommittee | None) -> dict[str, Any] | None:
+        if committee is None:
+            return None
+        return {
+            "id": committee.id,
+            "committee_code": committee.committee_code,
+            "name": committee.name,
+            "chamber": committee.chamber,
+            "committee_type": committee.committee_type,
+            "jurisdiction": committee.jurisdiction,
+            "source_url": committee.congress_url,
+        }
+
+    def _action_detail(self, action: BillAction) -> dict[str, Any]:
+        return {
+            "id": action.id,
+            "action_type": action.action_type,
+            "text": action.text,
+            "acted_at": _iso(action.acted_at),
+            "chamber": action.chamber,
+            "source_url": action.source_url,
+        }
+
+    def _text_version_detail(self, text_version: BillTextVersion) -> dict[str, Any]:
+        return {
+            "id": text_version.id,
+            "version_code": text_version.version_code,
+            "version_name": text_version.version_name,
+            "published_at": _iso(text_version.published_at),
+            "source_url": text_version.source_url,
+            "formats": text_version.formats or [],
+        }
+
+    def _position_detail(self, position: MemberVotePosition) -> dict[str, Any]:
+        member = position.member
+        return {
+            "member_identifier": position.member_identifier,
+            "member_name": position.member_name,
+            "party": position.party,
+            "state": position.state,
+            "district": member.district if member else None,
+            "position": position.position,
+            "congress_url": member.congress_url if member else None,
+            "is_current_member": member.current if member else None,
+        }
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _sortable_datetime(value: datetime | None) -> datetime:
+    if value is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _list_or_unavailable(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _matches_local_context(position: dict[str, Any], state: str | None, district: str | None) -> bool:
+    if state and str(position.get("state") or "").lower() != state.lower():
+        return False
+    if district and str(position.get("district") or "").zfill(2) != str(district).zfill(2):
+        return False
+    return bool(state or district)
+
+
+def _vote_margin(totals: dict[str, Any] | None) -> str | None:
+    if not totals:
+        return None
+    yea = _intish(totals.get("yea") or totals.get("yes"))
+    nay = _intish(totals.get("nay") or totals.get("no"))
+    if yea is None or nay is None:
+        return None
+    return str(abs(yea - nay))
+
+
+def _intish(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/backend/app/services/personalization.py
+++ b/backend/app/services/personalization.py
@@ -1,14 +1,187 @@
-"""Placeholder for personalization scoring logic."""
-from typing import Sequence
+"""Source-transparent ranking logic for primary-source feed events."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Sequence
 
 from app.models.update import GovernmentUpdate
 
 
 def rank_updates(updates: Sequence[GovernmentUpdate], context: dict | None = None) -> list[GovernmentUpdate]:
-    """Return updates sorted by placeholder relevance score.
+    """Return updates sorted by civic relevance without engagement heuristics."""
 
-    Later, incorporate collaborative filtering, embeddings similarity, urgency weights, and user preferences.
-    """
+    return sorted(
+        list(updates),
+        key=lambda update: score_update(update, context=context),
+        reverse=True,
+    )
 
-    # Currently returns items as-is; hook for future intelligence.
-    return list(updates)
+
+def score_update(update: GovernmentUpdate, context: dict | None = None) -> float:
+    """Score an update using auditable primary-source factors."""
+
+    factors = ranking_factors(update, context=context)
+    return float(sum(factors.values()))
+
+
+def ranking_factors(update: GovernmentUpdate, context: dict | None = None) -> dict[str, float]:
+    """Explainable scoring factors used by Today and feed ranking."""
+
+    context = context or {}
+    metadata = update.metadata_json or {}
+    tags = {str(tag).lower() for tag in (update.tags or [])}
+    now = _context_now(context)
+
+    return {
+        "source_freshness": _freshness_score(update, now),
+        "lifecycle_importance": _lifecycle_score(update, metadata, tags),
+        "local_relevance": _local_relevance_score(update, context, metadata),
+        "followed_object_relevance": _followed_object_score(update, context, metadata),
+        "source_transparency": _source_transparency_score(update, metadata),
+    }
+
+
+def _context_now(context: dict[str, Any]) -> datetime:
+    value = context.get("now")
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    return datetime.now(timezone.utc)
+
+
+def _freshness_score(update: GovernmentUpdate, now: datetime) -> float:
+    published_at = update.published_at
+    if published_at.tzinfo is None:
+        published_at = published_at.replace(tzinfo=timezone.utc)
+
+    age_hours = max((now - published_at).total_seconds() / 3600, 0)
+    if age_hours <= 6:
+        return 30
+    if age_hours <= 24:
+        return 22
+    if age_hours <= 72:
+        return 12
+    return 4
+
+
+def _lifecycle_score(update: GovernmentUpdate, metadata: dict[str, Any], tags: set[str]) -> float:
+    event_type = str(metadata.get("event_type") or metadata.get("card_type") or "").lower()
+    action_type = str(metadata.get("action_type") or "").lower()
+    status = str(metadata.get("status") or "").lower()
+
+    if update.vote_id or event_type == "vote" or "vote" in tags:
+        return 35
+    if update.hearing_id or event_type == "hearing" or "hearing" in tags:
+        return 28
+    if event_type in {"text_version", "new_text"} or "text" in tags:
+        return 24
+    if any(term in action_type or term in status for term in ("passed", "law", "president", "committee")):
+        return 22
+    if update.bill_action_id or event_type in {"bill_action", "bill"} or "bill" in tags:
+        return 18
+    return 8
+
+
+def _local_relevance_score(update: GovernmentUpdate, context: dict[str, Any], metadata: dict[str, Any]) -> float:
+    state = _normalized(context.get("state"))
+    district = _normalized(context.get("district"))
+    if not state:
+        return 0
+
+    update_states = {_normalized(value) for value in _metadata_values(metadata, "states")}
+    update_districts = {_normalized(value) for value in _metadata_values(metadata, "districts")}
+    member_states = {
+        _normalized(member.get("state"))
+        for member in _metadata_values(metadata, "members")
+        if isinstance(member, dict)
+    }
+    member_districts = {
+        _normalized(member.get("district"))
+        for member in _metadata_values(metadata, "members")
+        if isinstance(member, dict)
+    }
+
+    score = 0.0
+    if state in update_states or state in member_states:
+        score += 12
+    if district and (district in update_districts or district in member_districts):
+        score += 10
+    return score
+
+
+def _followed_object_score(update: GovernmentUpdate, context: dict[str, Any], metadata: dict[str, Any]) -> float:
+    followed_bills = _normalized_set(context.get("followed_bills"))
+    followed_members = _normalized_set(context.get("followed_members"))
+    followed_topics = _normalized_set(context.get("followed_topics"))
+
+    bill_ids = {
+        _normalized(value)
+        for value in [update.bill_id, metadata.get("bill_id"), metadata.get("bill_canonical_id")]
+        if value is not None
+    }
+    bill = getattr(update, "bill", None)
+    if bill is not None:
+        bill_ids.add(_normalized(getattr(bill, "canonical_id", "")))
+    vote = getattr(update, "vote", None)
+    vote_bill = getattr(vote, "bill", None) if vote is not None else None
+    if vote_bill is not None:
+        bill_ids.add(_normalized(getattr(vote_bill, "canonical_id", "")))
+    member_ids = {
+        _normalized(value)
+        for value in _metadata_values(metadata, "member_ids")
+        if value is not None
+    }
+    member_ids.update(
+        _normalized(member.get("bioguide_id") or member.get("id"))
+        for member in _metadata_values(metadata, "members")
+        if isinstance(member, dict)
+    )
+    topic_values = {_normalized(tag) for tag in (update.tags or [])}
+    topic_values.update(_normalized(value) for value in _metadata_values(metadata, "topics"))
+    topic_values.update(_normalized(value.get("name")) for value in _metadata_values(metadata, "subjects") if isinstance(value, dict))
+
+    score = 0.0
+    if followed_bills and followed_bills.intersection(bill_ids):
+        score += 18
+    if followed_members and followed_members.intersection(member_ids):
+        score += 15
+    if followed_topics and followed_topics.intersection(topic_values):
+        score += 10
+    return score
+
+
+def _source_transparency_score(update: GovernmentUpdate, metadata: dict[str, Any]) -> float:
+    source_trail = metadata.get("source_trail")
+    if isinstance(source_trail, list) and source_trail:
+        return 10
+    if update.url:
+        return 8
+    return 0
+
+
+def _metadata_values(metadata: dict[str, Any], key: str) -> list[Any]:
+    value = metadata.get(key)
+    if isinstance(value, list):
+        return value
+    if value in (None, ""):
+        return []
+    return [value]
+
+
+def _normalized_set(value: Any) -> set[str]:
+    if value in (None, ""):
+        return set()
+    if isinstance(value, str):
+        return {_normalized(item) for item in value.split(",") if item.strip()}
+    if isinstance(value, Sequence):
+        return {_normalized(item) for item in value if item not in (None, "")}
+    return {_normalized(value)}
+
+
+def _normalized(value: Any) -> str:
+    return str(value).strip().lower()

--- a/backend/tests/test_feed_m2.py
+++ b/backend/tests/test_feed_m2.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app import models as _models  # noqa: F401
+from app.db.base import Base
+from app.models.legislative import BillAction
+from app.models.update import BranchEnum
+from app.schemas.update import FeedQueryParams, GovernmentUpdateCreate
+from app.services.feed_service import FeedService
+from app.services.legislative_service import LegislativeDataService
+from app.services.update_service import UpdateService
+
+
+@pytest_asyncio.fixture()
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as db_session:
+        yield db_session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_today_feed_ranks_canonical_primary_source_events_with_detail_payloads(session) -> None:
+    now = datetime(2026, 6, 16, 18, tzinfo=timezone.utc)
+    legislative = LegislativeDataService(session)
+    updates = UpdateService(session)
+
+    await legislative.upsert_member(
+        {
+            "bioguide_id": "R000037",
+            "name": "CA 37 Representative",
+            "party": "D",
+            "state": "CA",
+            "district": "37",
+            "chamber": "House",
+            "congress_url": "https://www.congress.gov/member/ca-37-representative/R000037",
+        }
+    )
+    bill = await legislative.upsert_bill(
+        {
+            "congress": 119,
+            "bill_type": "hr",
+            "number": "1234",
+            "title": "Civic Data Transparency Act",
+            "short_title": "Civic Data Transparency Act",
+            "introduced_at": now - timedelta(days=10),
+            "latest_action_at": now - timedelta(hours=18),
+            "latest_action_text": "Passed House.",
+            "policy_area": "Government Operations and Politics",
+            "congress_url": "https://www.congress.gov/bill/119th-congress/house-bill/1234",
+            "cosponsors": [{"name": "Example Cosponsor"}],
+            "actions": [
+                {
+                    "sequence": 1,
+                    "action_type": "Passed House",
+                    "text": "Passed/agreed to in House.",
+                    "acted_at": now - timedelta(hours=18),
+                    "chamber": "House",
+                    "source_url": "https://www.congress.gov/bill/119th-congress/house-bill/1234/actions",
+                    "source_links": [
+                        {
+                            "label": "Congress.gov action",
+                            "url": "https://www.congress.gov/bill/119th-congress/house-bill/1234/actions",
+                            "source_system": "congress.gov",
+                            "retrieved_at": now,
+                            "supports": ["bill action"],
+                        }
+                    ],
+                }
+            ],
+            "text_versions": [
+                {
+                    "version_code": "ih",
+                    "version_name": "Introduced in House",
+                    "published_at": now - timedelta(days=10),
+                    "source_url": "https://www.congress.gov/bill/119th-congress/house-bill/1234/text/ih",
+                }
+            ],
+            "committees": [
+                {
+                    "committee_code": "hsgo",
+                    "name": "House Oversight and Accountability",
+                    "chamber": "House",
+                    "jurisdiction": "Government operations oversight.",
+                    "congress_url": "https://www.congress.gov/committee/house-oversight-and-accountability/hsgo",
+                }
+            ],
+            "source_links": [
+                {
+                    "label": "Congress.gov bill",
+                    "url": "https://www.congress.gov/bill/119th-congress/house-bill/1234",
+                    "source_system": "congress.gov",
+                    "retrieved_at": now,
+                    "supports": ["bill"],
+                }
+            ],
+        }
+    )
+    action = (await session.execute(select(BillAction))).scalars().first()
+    vote = await legislative.upsert_vote(
+        {
+            "chamber": "House",
+            "congress": 119,
+            "session": "2",
+            "roll_number": "42",
+            "vote_date": now - timedelta(hours=12),
+            "question": "On Passage",
+            "result": "Passed",
+            "bill_id": bill.id,
+            "source_url": "https://clerk.house.gov/Votes/202642",
+            "totals": {"yea": 220, "nay": 210},
+            "party_split": {"D": {"yea": 200}, "R": {"nay": 190}},
+            "positions": [
+                {
+                    "bioguide_id": "R000037",
+                    "name": "CA 37 Representative",
+                    "state": "CA",
+                    "party": "D",
+                    "position": "yea",
+                }
+            ],
+            "source_links": [
+                {
+                    "label": "House Clerk roll call",
+                    "url": "https://clerk.house.gov/Votes/202642",
+                    "source_system": "house.gov",
+                    "retrieved_at": now,
+                    "supports": ["vote result", "member positions"],
+                }
+            ],
+        }
+    )
+    hearing = await legislative.upsert_hearing(
+        {
+            "event_id": "116500",
+            "congress": 119,
+            "chamber": "House",
+            "title": "Oversight hearing on civic data access",
+            "meeting_type": "Hearing",
+            "status": "Scheduled",
+            "scheduled_at": now + timedelta(days=2),
+            "location": "Rayburn 2154",
+            "committee": {
+                "committee_code": "hsgo",
+                "name": "House Oversight and Accountability",
+                "chamber": "House",
+                "jurisdiction": "Government operations oversight.",
+                "congress_url": "https://www.congress.gov/committee/house-oversight-and-accountability/hsgo",
+            },
+            "source_url": "https://www.congress.gov/event/119th-congress/house-event/116500",
+            "source_links": [
+                {
+                    "label": "Congress.gov hearing",
+                    "url": "https://www.congress.gov/event/119th-congress/house-event/116500",
+                    "source_system": "congress.gov",
+                    "retrieved_at": now,
+                    "supports": ["hearing schedule"],
+                }
+            ],
+        }
+    )
+    await session.flush()
+
+    await updates.create_update(
+        _update(
+            "generic-1",
+            "Generic agency post",
+            now,
+            tags=["agency"],
+            url="https://www.example.gov/generic",
+        )
+    )
+    await updates.create_update(
+        _update(
+            "bill-action-1",
+            "House passes Civic Data Transparency Act",
+            now - timedelta(hours=18),
+            tags=["bill", "lifecycle"],
+            url="https://www.congress.gov/bill/119th-congress/house-bill/1234",
+            bill_id=bill.id,
+            bill_action_id=action.id if action else None,
+            metadata={"event_type": "bill_action", "bill_canonical_id": bill.canonical_id},
+        )
+    )
+    await updates.create_update(
+        _update(
+            "vote-1",
+            "House records roll-call vote on civic data bill",
+            now - timedelta(hours=12),
+            tags=["vote"],
+            url="https://clerk.house.gov/Votes/202642",
+            bill_id=bill.id,
+            vote_id=vote.id,
+            metadata={"event_type": "vote", "bill_canonical_id": bill.canonical_id},
+        )
+    )
+    await updates.create_update(
+        _update(
+            "hearing-1",
+            "House Oversight schedules civic data access hearing",
+            now - timedelta(hours=20),
+            event_date=hearing.scheduled_at,
+            tags=["hearing", "oversight"],
+            url="https://www.congress.gov/event/119th-congress/house-event/116500",
+            hearing_id=hearing.id,
+            metadata={"event_type": "hearing", "topics": ["oversight"]},
+        )
+    )
+    await session.commit()
+
+    service = FeedService(session)
+    items, total = await service.list_updates(
+        FeedQueryParams(
+            sort="today",
+            followed_bills=bill.canonical_id,
+            followed_topics="oversight",
+            state="CA",
+            district="37",
+            limit=10,
+        )
+    )
+
+    assert total == 4
+    assert [item["card_type"] for item in items[:3]] == ["vote", "hearing", "bill"]
+    assert items[0]["headline"] == "House records roll-call vote on civic data bill"
+    assert items[0]["rank_context"]["factors"]["lifecycle_importance"] > 0
+    assert items[0]["rank_context"]["factors"]["followed_object_relevance"] > 0
+    assert items[0]["source_trail_status"] == "available"
+    assert items[0]["detail"]["vote"]["local_representative_positions"][0]["member_name"] == "CA 37 Representative"
+    assert items[1]["detail"]["hearing"]["unavailable"]["transcripts"] == "Official transcript is not published yet."
+    assert items[2]["detail"]["bill"]["vote_eligible"] is True
+    assert "personal position" in items[2]["detail"]["bill"]["user_position_prompt"]
+
+
+def _update(
+    external_id: str,
+    headline: str,
+    published_at: datetime,
+    *,
+    tags: list[str],
+    url: str,
+    event_date: datetime | None = None,
+    bill_id: int | None = None,
+    bill_action_id: int | None = None,
+    vote_id: int | None = None,
+    hearing_id: int | None = None,
+    metadata: dict | None = None,
+) -> GovernmentUpdateCreate:
+    return GovernmentUpdateCreate(
+        external_id=external_id,
+        source="congress.gov",
+        branch=BranchEnum.LEGISLATIVE,
+        headline=headline,
+        summary=f"Summary for {headline}",
+        full_text=None,
+        published_at=published_at,
+        event_date=event_date,
+        url=url,
+        bill_id=bill_id,
+        bill_action_id=bill_action_id,
+        vote_id=vote_id,
+        hearing_id=hearing_id,
+        tags=tags,
+        metadata=metadata or {},
+    )

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  root: true,
+  extends: ['expo'],
+  ignorePatterns: ['node_modules/', '.expo/', 'dist/', 'web-build/']
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,9 @@
         "@types/react": "^18.2.61",
         "@types/react-native": "^0.73.0",
         "babel-plugin-module-resolver": "^5.0.2",
+        "eslint": "^8.57.1",
+        "eslint-config-expo": "^8.0.1",
+        "eslint-plugin-expo": "^0.1.1",
         "typescript": "^5.3.3"
       }
     },
@@ -2137,6 +2140,173 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@expo/bunyan": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@expo/bunyan/-/bunyan-4.0.1.tgz",
@@ -3333,6 +3503,44 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@ide/backoff": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
@@ -3572,6 +3780,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3605,6 +3832,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
       }
     },
     "node_modules/@npmcli/fs": {
@@ -5570,6 +5807,13 @@
         "nanoid": "^3.1.23"
       }
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -5624,6 +5868,17 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/hammerjs": {
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
@@ -5653,6 +5908,13 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.1",
@@ -5712,6 +5974,555 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
+      "integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/type-utils": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
+      "integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
+      "integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
+      "integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
+      "integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
+      "integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
+      "integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.9.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@urql/core": {
       "version": "2.3.6",
@@ -5786,6 +6597,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -5809,6 +6630,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/anser": {
@@ -5947,6 +6785,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -5954,6 +6815,104 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
@@ -6679,14 +7638,14 @@
       "license": "ISC"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -7347,6 +8306,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -7527,6 +8493,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -7663,9 +8642,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -7748,6 +8727,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7769,6 +8776,19 @@
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "hasown": "^2.0.2"
       },
       "engines": {
@@ -7819,6 +8839,516 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-expo": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-expo/-/eslint-config-expo-8.0.1.tgz",
+      "integrity": "sha512-r9PSgkuZk5Q5ALbk1yowYwEIj0oqO/ikRO9TNhpx2DzSOdK65y3urgFI04WYvQzMr9q1fnA62wr9iGfrsmF5pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.9.0",
+        "@typescript-eslint/parser": "^8.9.0",
+        "eslint-import-resolver-typescript": "^3.6.3",
+        "eslint-plugin-expo": "^0.1.0",
+        "eslint-plugin-import": "^2.30.0",
+        "eslint-plugin-react": "^7.36.1",
+        "eslint-plugin-react-hooks": "^4.6.2"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.10"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-expo": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-expo/-/eslint-plugin-expo-0.1.1.tgz",
+      "integrity": "sha512-A3TW7ybtfEYF4rBofk0YX3Oj0NxQ8dGOvDvQuttIytJpheGIEVsivpNwF9NWHYeEZo3gtuzP8qk55tJ4NebFWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.9.0",
+        "@typescript-eslint/utils": "^8.9.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8 <9"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/eslint/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -7830,6 +9360,42 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
@@ -8155,6 +9721,20 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -8247,11 +9827,42 @@
         "node": "*"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-4.1.1.tgz",
       "integrity": "sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==",
       "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -8355,6 +9966,28 @@
       "dependencies": {
         "micromatch": "^4.0.2"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/flow-enums-runtime": {
       "version": "0.0.6",
@@ -8710,6 +10343,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/getenv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
@@ -8750,6 +10396,35 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -8805,6 +10480,13 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "15.8.0",
@@ -8906,9 +10588,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9309,6 +10991,29 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -9322,12 +11027,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9805,6 +11510,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -10121,6 +11844,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -10157,6 +11887,20 @@
         "is-buffer": "~1.1.1"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10176,6 +11920,32 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -10203,6 +11973,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lighthouse-logger": {
@@ -10447,6 +12231,13 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.throttle": {
@@ -11298,9 +13089,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11438,6 +13229,29 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -11490,6 +13304,25 @@
       },
       "engines": {
         "node": ">= 0.10.5"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/node-fetch": {
@@ -11672,6 +13505,75 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -11729,6 +13631,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -11933,6 +13853,29 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module/node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse-json": {
       "version": "4.0.0",
@@ -12312,6 +14255,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
@@ -13121,6 +15074,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-workspace-root": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.0.tgz",
@@ -13846,6 +15809,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -14011,6 +15981,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
@@ -14099,6 +16108,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-eof": {
@@ -14440,6 +16459,36 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -14490,17 +16539,69 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -14768,6 +16869,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.1.tgz",
@@ -14796,6 +16935,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-join": {
@@ -15062,6 +17211,16 @@
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
       "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==",
       "license": "MIT"
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,20 @@
     "@types/react": "^18.2.61",
     "@types/react-native": "^0.73.0",
     "babel-plugin-module-resolver": "^5.0.2",
+    "eslint": "^8.57.1",
+    "eslint-config-expo": "^8.0.1",
+    "eslint-plugin-expo": "^0.1.1",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "@typescript-eslint/eslint-plugin": "8.9.0",
+    "@typescript-eslint/parser": "8.9.0",
+    "@typescript-eslint/scope-manager": "8.9.0",
+    "@typescript-eslint/type-utils": "8.9.0",
+    "@typescript-eslint/types": "8.9.0",
+    "@typescript-eslint/typescript-estree": "8.9.0",
+    "@typescript-eslint/utils": "8.9.0",
+    "@typescript-eslint/visitor-keys": "8.9.0",
+    "eslint-plugin-expo": "0.1.1"
   }
 }

--- a/frontend/src/components/UpdateCard.tsx
+++ b/frontend/src/components/UpdateCard.tsx
@@ -91,7 +91,7 @@ const UpdateCard = ({ item, onPress, onSave, isSaved = false, compact = false }:
 
         {/* Summary */}
         <Text style={[styles.summary, { color: neutral.textSecondary }]} numberOfLines={2}>
-          {item.summary}
+          {item.summary ?? 'Official summary has not been published yet.'}
         </Text>
 
         {/* Footer */}

--- a/frontend/src/context/UserPreferencesContext.tsx
+++ b/frontend/src/context/UserPreferencesContext.tsx
@@ -19,10 +19,17 @@ export type UserPreferences = {
   followedMembers: string[];
   followedBills: string[];
   followedTopics: string[];
+  followedCommittees: string[];
+  billPositions: Record<string, UserBillPosition>;
   homeDistrict: UserDistrict | null;
   currentMembers: CurrentMember[];
   currentMembersUpdatedAt: string | null;
   districtLookupAmbiguity: string | null;
+};
+
+export type UserBillPosition = {
+  position: 'yea' | 'nay' | 'present' | 'abstain' | 'undecided';
+  updatedAt: string;
 };
 
 const defaultPreferences: UserPreferences = {
@@ -36,6 +43,8 @@ const defaultPreferences: UserPreferences = {
   followedMembers: [],
   followedBills: [],
   followedTopics: [],
+  followedCommittees: [],
+  billPositions: {},
   homeDistrict: null,
   currentMembers: [],
   currentMembersUpdatedAt: null,
@@ -55,6 +64,10 @@ type UserPreferencesContextType = {
   unfollowBill: (billId: string) => void;
   followTopic: (topic: string) => void;
   unfollowTopic: (topic: string) => void;
+  followCommittee: (committeeId: string) => void;
+  unfollowCommittee: (committeeId: string) => void;
+  setBillPosition: (billId: string, position: UserBillPosition['position']) => void;
+  clearBillPosition: (billId: string) => void;
   setDistrictMemberMapping: (mapping: DistrictLookupResponse) => void;
   clearDistrictMemberMapping: () => void;
   completeOnboarding: () => void;
@@ -172,6 +185,43 @@ export const UserPreferencesProvider = ({ children }: PropsWithChildren) => {
     }));
   }, []);
 
+  const followCommittee = useCallback((committeeId: string) => {
+    setPreferences(prev => ({
+      ...prev,
+      followedCommittees: prev.followedCommittees.includes(committeeId)
+        ? prev.followedCommittees
+        : [...prev.followedCommittees, committeeId]
+    }));
+  }, []);
+
+  const unfollowCommittee = useCallback((committeeId: string) => {
+    setPreferences(prev => ({
+      ...prev,
+      followedCommittees: prev.followedCommittees.filter(id => id !== committeeId)
+    }));
+  }, []);
+
+  const setBillPosition = useCallback((billId: string, position: UserBillPosition['position']) => {
+    setPreferences(prev => ({
+      ...prev,
+      billPositions: {
+        ...prev.billPositions,
+        [billId]: {
+          position,
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    }));
+  }, []);
+
+  const clearBillPosition = useCallback((billId: string) => {
+    setPreferences(prev => {
+      const nextPositions = { ...prev.billPositions };
+      delete nextPositions[billId];
+      return { ...prev, billPositions: nextPositions };
+    });
+  }, []);
+
   const setDistrictMemberMapping = useCallback((mapping: DistrictLookupResponse) => {
     setPreferences(prev => ({
       ...prev,
@@ -237,6 +287,10 @@ export const UserPreferencesProvider = ({ children }: PropsWithChildren) => {
         unfollowBill,
         followTopic,
         unfollowTopic,
+        followCommittee,
+        unfollowCommittee,
+        setBillPosition,
+        clearBillPosition,
         setDistrictMemberMapping,
         clearDistrictMemberMapping,
         completeOnboarding,

--- a/frontend/src/features/calendar/screens/CalendarScreen.tsx
+++ b/frontend/src/features/calendar/screens/CalendarScreen.tsx
@@ -26,8 +26,8 @@ const CalendarScreen = () => {
   const [loading, setLoading] = useState(false);
   const [viewMode, setViewMode] = useState<'month' | 'year'>('month');
 
-  const startOfMonth = currentDate.startOf('month');
-  const endOfMonth = currentDate.endOf('month');
+  const startOfMonth = useMemo(() => currentDate.startOf('month'), [currentDate]);
+  const endOfMonth = useMemo(() => currentDate.endOf('month'), [currentDate]);
   const startDayOfWeek = startOfMonth.day(); // 0-6
   const daysInMonth = currentDate.daysInMonth();
 
@@ -50,7 +50,7 @@ const CalendarScreen = () => {
       setLoading(false);
     };
     loadUpdates();
-  }, [currentDate, viewMode]);
+  }, [currentDate, endOfMonth, startOfMonth, viewMode]);
 
   // Generate calendar grid
   const calendarDays = useMemo(() => {
@@ -64,7 +64,7 @@ const CalendarScreen = () => {
       days.push(startOfMonth.date(i));
     }
     return days;
-  }, [currentDate]);
+  }, [daysInMonth, startDayOfWeek, startOfMonth]);
 
   // Group updates by date for the calendar dots
   const updatesByDate = useMemo(() => {

--- a/frontend/src/features/calendar/screens/YearView.tsx
+++ b/frontend/src/features/calendar/screens/YearView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, Text, View, Pressable, Dimensions } from 'react-native';
+import { StyleSheet, Text, View, Pressable } from 'react-native';
 import dayjs from 'dayjs';
 import { GovernmentUpdate } from '@services/updatesService';
 

--- a/frontend/src/features/explore/screens/ExploreScreen.tsx
+++ b/frontend/src/features/explore/screens/ExploreScreen.tsx
@@ -47,7 +47,7 @@ const trendingTopics = [
 ];
 
 const ExploreScreen = () => {
-  const { neutral, branch: branchColors, semantic, spacing, borderRadius } = useTheme();
+  const { neutral, branch: branchColors, semantic } = useTheme();
   const navigation = useNavigation<NavigationProp>();
   const { isSaved, toggleSave } = useSavedItems();
 
@@ -59,6 +59,8 @@ const ExploreScreen = () => {
   const contextKey = useMemo(() => {
     if (activeQuickFilter === 'trending') return 'trending';
     if (activeQuickFilter === 'urgent') return 'urgent';
+    if (activeQuickFilter === 'hearings') return 'hearings';
+    if (activeQuickFilter === 'votes') return 'votes';
     if (activeBranch === 'legislative') return 'legislative';
     if (activeBranch === 'executive') return 'executive';
     if (activeBranch === 'judicial') return 'judicial';
@@ -74,7 +76,7 @@ const ExploreScreen = () => {
     const query = searchQuery.toLowerCase();
     return items.filter(item =>
       item.headline.toLowerCase().includes(query) ||
-      item.summary.toLowerCase().includes(query) ||
+      (item.summary ?? '').toLowerCase().includes(query) ||
       item.tags.some(tag => tag.toLowerCase().includes(query))
     );
   }, [items, searchQuery]);

--- a/frontend/src/features/feed/components/FeedCard.tsx
+++ b/frontend/src/features/feed/components/FeedCard.tsx
@@ -28,11 +28,13 @@ const FeedCard = ({ item, onPress, onSave }: Props) => {
 
         <Text style={styles.headline}>{item.headline}</Text>
         <Text style={styles.summary} numberOfLines={3}>
-          {item.summary}
+          {item.summary ?? 'Official summary has not been published yet.'}
         </Text>
 
         <View style={styles.footerRow}>
-          <Text style={styles.source}>{item.source.toUpperCase()}</Text>
+          <Text style={styles.source}>
+            {(item.card_type ?? item.source).toUpperCase()}
+          </Text>
           <View style={styles.tagRow}>
             {item.tags.slice(0, 2).map(tag => (
               <View key={tag} style={styles.tagChip}>

--- a/frontend/src/features/feed/data/mockFeed.ts
+++ b/frontend/src/features/feed/data/mockFeed.ts
@@ -3,30 +3,167 @@ import { FeedItem } from '../types';
 export const mockFeed: FeedItem[] = [
   {
     id: 1,
-    headline: 'Senate passes bipartisan technology modernization bill',
-    summary: 'The Senate approved sweeping upgrades for federal technology infrastructure to strengthen cybersecurity and AI readiness.',
-    published_at: new Date().toISOString(),
-    branch: 'senate',
+    headline: 'House records roll-call vote on Civic Data Transparency Act',
+    summary: 'Members voted on final passage with official roll-call totals and member positions available.',
+    published_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    branch: 'house',
     source: 'congress.gov',
-    url: 'https://www.congress.gov/bill',
-    tags: ['Technology', 'Cybersecurity']
+    url: 'https://clerk.house.gov/Votes/202642',
+    tags: ['vote', 'Technology'],
+    card_type: 'vote',
+    rank_context: {
+      score: 98,
+      factors: {
+        source_freshness: 30,
+        lifecycle_importance: 35,
+        local_relevance: 22,
+        followed_object_relevance: 3,
+        source_transparency: 8
+      },
+      reasons: ['Roll-call votes are high-importance primary-source events.', 'Official source links are available on the card.']
+    },
+    source_trail_status: 'available',
+    source_trail: [
+      {
+        label: 'House Clerk roll call',
+        source: 'house.gov',
+        url: 'https://clerk.house.gov/Votes/202642',
+        supports: ['vote result', 'member positions']
+      }
+    ],
+    detail: {
+      vote: {
+        canonical_id: 'vote-house-119-2-42',
+        chamber: 'House',
+        congress: 119,
+        session: '2',
+        roll_number: '42',
+        vote_date: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        question: 'On Passage',
+        result: 'Passed',
+        margin: '10',
+        totals: { yea: 220, nay: 210 },
+        party_split: { D: { yea: 200 }, R: { nay: 190 } },
+        positions: [
+          { member_identifier: 'R000037', member_name: 'CA 37 Representative', party: 'D', state: 'CA', district: '37', position: 'yea' },
+          { member_identifier: 'T000001', member_name: 'Texas Example Member', party: 'R', state: 'TX', district: '12', position: 'nay' }
+        ],
+        local_representative_positions: [
+          { member_identifier: 'R000037', member_name: 'CA 37 Representative', party: 'D', state: 'CA', district: '37', position: 'yea' }
+        ],
+        linked_bill: { display_number: 'HR 1234', title: 'Civic Data Transparency Act' },
+        source_url: 'https://clerk.house.gov/Votes/202642',
+        unavailable: {}
+      }
+    }
   },
   {
     id: 2,
-    headline: 'Supreme Court schedules emergency hearing on data privacy case',
-    summary: 'Justices fast-track arguments on a case that could reshape digital privacy protections for Americans.',
-    published_at: new Date().toISOString(),
-    branch: 'judicial',
-    source: 'supremecourt.gov',
-    tags: ['Privacy', 'Courts']
+    headline: 'House Oversight schedules civic data access hearing',
+    summary: 'The committee posted a hearing notice with schedule, jurisdiction, and source-backed availability states.',
+    published_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    event_date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+    branch: 'house',
+    source: 'congress.gov',
+    url: 'https://www.congress.gov/event/119th-congress/house-event/116500',
+    tags: ['hearing', 'oversight'],
+    card_type: 'hearing',
+    source_trail_status: 'available',
+    source_trail: [
+      {
+        label: 'Congress.gov hearing',
+        source: 'congress.gov',
+        url: 'https://www.congress.gov/event/119th-congress/house-event/116500',
+        supports: ['hearing schedule']
+      }
+    ],
+    detail: {
+      hearing: {
+        canonical_id: 'hearing-119-house-116500',
+        event_id: '116500',
+        congress: 119,
+        chamber: 'House',
+        title: 'Oversight hearing on civic data access',
+        meeting_type: 'Hearing',
+        status: 'Scheduled',
+        scheduled_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+        location: 'Rayburn 2154',
+        committee: {
+          committee_code: 'hsgo',
+          name: 'House Oversight and Accountability',
+          jurisdiction: 'Government operations oversight.'
+        },
+        witnesses: [],
+        related_bills: [{ display_number: 'HR 1234', title: 'Civic Data Transparency Act' }],
+        videos: [],
+        transcripts: [],
+        source_url: 'https://www.congress.gov/event/119th-congress/house-event/116500',
+        follow_supported: true,
+        alert_affordance: 'Follow this committee for hearing alerts.',
+        unavailable: {
+          witnesses: 'Official witness details are not published yet.',
+          videos: 'Official video is not published yet.',
+          transcripts: 'Official transcript is not published yet.'
+        }
+      }
+    }
   },
   {
     id: 3,
-    headline: 'EPA announces urgent air quality rule for Western states',
-    summary: 'The EPA issued an emergency rule targeting wildfire-induced pollution, coordinating with regional agencies for rapid response.',
-    published_at: new Date().toISOString(),
-    branch: 'executive',
-    source: 'epa.gov',
-    tags: ['Environment', 'Urgent']
+    headline: 'House passes Civic Data Transparency Act',
+    summary: 'The bill detail includes lifecycle status, committees, text versions, related votes, and official source trail.',
+    published_at: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    branch: 'house',
+    source: 'congress.gov',
+    url: 'https://www.congress.gov/bill/119th-congress/house-bill/1234',
+    tags: ['bill', 'lifecycle'],
+    card_type: 'bill',
+    source_trail_status: 'available',
+    source_trail: [
+      {
+        label: 'Congress.gov bill',
+        source: 'congress.gov',
+        url: 'https://www.congress.gov/bill/119th-congress/house-bill/1234',
+        supports: ['bill']
+      }
+    ],
+    detail: {
+      bill: {
+        canonical_id: '119-hr-1234',
+        display_number: 'HR 1234',
+        title: 'Civic Data Transparency Act',
+        short_title: 'Civic Data Transparency Act',
+        status: 'Passed House.',
+        origin_chamber: 'House',
+        policy_area: 'Government Operations and Politics',
+        introduced_at: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
+        latest_action_at: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+        sponsors: [{ name: 'Example Sponsor' }],
+        cosponsors: [{ name: 'Example Cosponsor' }],
+        committees: [{ committee_code: 'hsgo', name: 'House Oversight and Accountability' }],
+        timeline: [
+          {
+            id: 1,
+            action_type: 'Passed House',
+            text: 'Passed/agreed to in House.',
+            acted_at: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+            chamber: 'House',
+            source_url: 'https://www.congress.gov/bill/119th-congress/house-bill/1234/actions'
+          }
+        ],
+        text_versions: [{ version_name: 'Introduced in House', source_url: 'https://www.congress.gov/bill/119th-congress/house-bill/1234/text' }],
+        amendments: [],
+        related_bills: [],
+        cbo_cost_estimates: [],
+        crs_reports: [],
+        votes: [{ roll_number: '42', result: 'Passed' }],
+        vote_eligible: true,
+        user_position_prompt: 'Record a personal position for comparison. This is civic tracking, not an official congressional vote.',
+        source_url: 'https://www.congress.gov/bill/119th-congress/house-bill/1234',
+        unavailable: {
+          amendments: 'No official amendments are published yet.'
+        }
+      }
+    }
   }
 ];

--- a/frontend/src/features/feed/hooks/useFeed.ts
+++ b/frontend/src/features/feed/hooks/useFeed.ts
@@ -2,13 +2,23 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { fetchFeed } from '@services/feedService';
 import { mockFeed } from '@features/feed/data/mockFeed';
-import { FeedItem } from '../types';
+import { CivicCardType, FeedItem } from '../types';
 
 type FeedState = {
   loading: boolean;
   error: string | null;
   items: FeedItem[];
   total: number;
+};
+
+export type FeedContextOptions = {
+  followedBills?: string[];
+  followedMembers?: string[];
+  followedTopics?: string[];
+  state?: string | null;
+  district?: string | null;
+  cardType?: CivicCardType;
+  limit?: number;
 };
 
 const initialState: FeedState = {
@@ -18,20 +28,22 @@ const initialState: FeedState = {
   total: 0
 };
 
-export const useFeed = (contextKey: string) => {
+const defaultFeedOptions: FeedContextOptions = {};
+
+export const useFeed = (contextKey: string, options: FeedContextOptions = defaultFeedOptions) => {
   const [state, setState] = useState<FeedState>(initialState);
 
   const load = useCallback(async () => {
     setState(prev => ({ ...prev, loading: true, error: null }));
     try {
-      const params = mapContextToParams(contextKey);
+      const params = mapContextToParams(contextKey, options);
       const data = await fetchFeed(params);
       setState({ loading: false, error: null, items: data.items, total: data.total });
     } catch (error) {
       console.warn('Failed to load feed', error);
       setState({ loading: false, error: 'Unable to load feed right now.', items: mockFeed, total: mockFeed.length });
     }
-  }, [contextKey]);
+  }, [contextKey, options]);
 
   useEffect(() => {
     load();
@@ -40,19 +52,37 @@ export const useFeed = (contextKey: string) => {
   return { ...state, reload: load };
 };
 
-const mapContextToParams = (contextKey: string) => {
+const mapContextToParams = (contextKey: string, options: FeedContextOptions) => {
+  const base = {
+    followed_bills: options.followedBills?.join(',') || undefined,
+    followed_members: options.followedMembers?.join(',') || undefined,
+    followed_topics: options.followedTopics?.join(',') || undefined,
+    state: options.state ?? undefined,
+    district: options.district ?? undefined,
+    card_type: options.cardType,
+    limit: options.limit,
+  };
+
   switch (contextKey) {
+    case 'today':
+      return { ...base, sort: 'today', limit: options.limit ?? 20 };
     case 'trending':
-      return { sort: 'trending', limit: 20 };
+      return { ...base, sort: 'trending', limit: options.limit ?? 20 };
     case 'urgent':
-      return { sort: 'urgent', limit: 20 };
+      return { ...base, sort: 'urgent', limit: options.limit ?? 20 };
     case 'legislative':
-      return { branch: 'legislative', limit: 30 };
+      return { ...base, branch: 'legislative', limit: options.limit ?? 30 };
+    case 'votes':
+      return { ...base, branch: 'legislative', card_type: 'vote', limit: options.limit ?? 30 };
+    case 'hearings':
+      return { ...base, branch: 'legislative', card_type: 'hearing', limit: options.limit ?? 30 };
+    case 'myGovernment':
+      return { ...base, sort: 'today', limit: options.limit ?? 8 };
     case 'executive':
-      return { branch: 'executive', limit: 30 };
+      return { ...base, branch: 'executive', limit: options.limit ?? 30 };
     case 'judicial':
-      return { branch: 'judicial', limit: 30 };
+      return { ...base, branch: 'judicial', limit: options.limit ?? 30 };
     default:
-      return { limit: 20 };
+      return { ...base, limit: options.limit ?? 20 };
   }
 };

--- a/frontend/src/features/feed/screens/FeedScreen.tsx
+++ b/frontend/src/features/feed/screens/FeedScreen.tsx
@@ -1,11 +1,16 @@
 import React, { useCallback } from 'react';
 import { ActivityIndicator, FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import FeedCard from '@features/feed/components/FeedCard';
 import { useFeed } from '@features/feed/hooks/useFeed';
+import { RootStackParamList } from '@navigation/RootNavigator';
 import { useTheme } from '@theme/ThemeProvider';
 
 import { FeedItem } from '../types';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 type Props = {
   contextKey: string;
@@ -14,8 +19,11 @@ type Props = {
 const FeedScreen = ({ contextKey }: Props) => {
   const { neutral } = useTheme();
   const { items, loading, error, reload } = useFeed(contextKey);
+  const navigation = useNavigation<NavigationProp>();
 
-  const renderItem = useCallback(({ item }: { item: FeedItem }) => <FeedCard item={item} />, []);
+  const renderItem = useCallback(({ item }: { item: FeedItem }) => (
+    <FeedCard item={item} onPress={() => navigation.navigate('UpdateDetail', { item })} />
+  ), [navigation]);
 
   return (
     <View style={[styles.container, { backgroundColor: neutral.background }]}> 

--- a/frontend/src/features/feed/types/index.ts
+++ b/frontend/src/features/feed/types/index.ts
@@ -70,14 +70,133 @@ export type CivicCard = {
   metadata?: Record<string, unknown> | null;
 };
 
+export type RankContext = {
+  score: number;
+  factors: Record<string, number>;
+  reasons: string[];
+};
+
+export type SourceTrailItem = CivicSource & {
+  confidence?: string;
+  source_category?: string;
+};
+
+export type BillTimelineItem = {
+  id: number;
+  action_type?: string | null;
+  text: string;
+  acted_at?: string | null;
+  chamber?: string | null;
+  source_url?: string | null;
+};
+
+export type BillDetail = {
+  canonical_id: string;
+  display_number: string;
+  title: string;
+  short_title?: string | null;
+  status: string;
+  origin_chamber?: string | null;
+  policy_area?: string | null;
+  introduced_at?: string | null;
+  latest_action_at?: string | null;
+  sponsors: Record<string, unknown>[];
+  cosponsors: Record<string, unknown>[];
+  committees: Record<string, unknown>[];
+  timeline: BillTimelineItem[];
+  text_versions: Record<string, unknown>[];
+  amendments: Record<string, unknown>[];
+  related_bills: Record<string, unknown>[];
+  cbo_cost_estimates: Record<string, unknown>[];
+  crs_reports: Record<string, unknown>[];
+  votes: Record<string, unknown>[];
+  vote_eligible: boolean;
+  user_position_prompt?: string | null;
+  source_url?: string | null;
+  unavailable: Record<string, string | null>;
+};
+
+export type VotePosition = {
+  member_identifier: string;
+  member_name: string;
+  party?: string | null;
+  state?: string | null;
+  district?: string | null;
+  position: string;
+  congress_url?: string | null;
+  is_current_member?: boolean | null;
+};
+
+export type VoteDetail = {
+  canonical_id: string;
+  chamber: string;
+  congress: number;
+  session?: string | null;
+  roll_number: string;
+  vote_date?: string | null;
+  question: string;
+  result?: string | null;
+  margin?: string | null;
+  totals: Record<string, unknown>;
+  party_split: Record<string, unknown>;
+  positions: VotePosition[];
+  local_representative_positions: VotePosition[];
+  linked_bill?: Record<string, unknown> | null;
+  source_url?: string | null;
+  unavailable: Record<string, string | null>;
+};
+
+export type HearingDetail = {
+  canonical_id: string;
+  event_id: string;
+  congress?: number | null;
+  chamber: string;
+  title: string;
+  meeting_type?: string | null;
+  status?: string | null;
+  scheduled_at?: string | null;
+  location?: string | null;
+  committee?: Record<string, unknown> | null;
+  witnesses: Record<string, unknown>[];
+  related_bills: Record<string, unknown>[];
+  videos: Record<string, unknown>[];
+  transcripts: Record<string, unknown>[];
+  source_url?: string | null;
+  follow_supported: boolean;
+  alert_affordance?: string | null;
+  unavailable: Record<string, string | null>;
+};
+
+export type FeedItemDetail = {
+  bill?: BillDetail;
+  vote?: VoteDetail;
+  hearing?: HearingDetail;
+};
+
 export type FeedItem = {
   id: number;
+  external_id?: string;
   headline: string;
-  summary: string;
+  summary?: string | null;
+  full_text?: string | null;
   published_at: string;
+  event_date?: string | null;
   branch: Branch;
   source: string;
   url?: string;
+  bill_id?: number | null;
+  bill_action_id?: number | null;
+  vote_id?: number | null;
+  hearing_id?: number | null;
   tags: string[];
-  metadata?: Record<string, unknown>;
+  card_type?: CivicCardType;
+  rank_context?: RankContext;
+  involved?: CivicEntity[];
+  key_claims?: CivicClaim[];
+  source_trail?: SourceTrailItem[];
+  source_trail_status?: SourceTrailStatus;
+  source_trail_note?: string | null;
+  detail?: FeedItemDetail;
+  entities?: { id: number; name: string; type: string; slug: string }[];
+  metadata?: Record<string, unknown> | null;
 };

--- a/frontend/src/features/settings/screens/NotificationSettingsScreen.tsx
+++ b/frontend/src/features/settings/screens/NotificationSettingsScreen.tsx
@@ -21,7 +21,7 @@ const timeOptions = [
 ];
 
 const NotificationSettingsScreen = ({ navigation }: Props) => {
-  const { neutral, branch: branchColors, spacing } = useTheme();
+  const { neutral, branch: branchColors } = useTheme();
   const { preferences, setNotificationPreferences } = useUserPreferences();
 
   const [showTimePicker, setShowTimePicker] = useState(false);

--- a/frontend/src/features/today/screens/TodayScreen.tsx
+++ b/frontend/src/features/today/screens/TodayScreen.tsx
@@ -12,315 +12,192 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { useDailyBrief } from '@features/dailyBrief/hooks/useDailyBrief';
-import { useTheme } from '@theme/ThemeProvider';
-import { useSavedItems } from '../../../context/SavedItemsContext';
-import { FeedItem, Branch } from '@features/feed/types';
-import dayjs from '@utils/dayjs';
+import { useFeed } from '@features/feed/hooks/useFeed';
+import { CivicCardType, FeedItem } from '@features/feed/types';
+import { useUserPreferences } from '@context/UserPreferencesContext';
 import { RootStackParamList } from '@navigation/RootNavigator';
+import { useTheme } from '@theme/ThemeProvider';
+import dayjs from '@utils/dayjs';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
-const branchConfig: Record<string, { icon: keyof typeof Ionicons.glyphMap; label: string }> = {
-  legislative: { icon: 'business', label: 'Legislative' },
-  house: { icon: 'business', label: 'House' },
-  senate: { icon: 'business', label: 'Senate' },
-  executive: { icon: 'document-text', label: 'Executive' },
-  judicial: { icon: 'scale', label: 'Judicial' },
-  agency: { icon: 'grid', label: 'Agency' },
+const cardTypeOrder: CivicCardType[] = ['vote', 'hearing', 'bill', 'alert', 'money'];
+const cardTypeLabels: Record<CivicCardType, string> = {
+  bill: 'Bills',
+  vote: 'Votes',
+  hearing: 'Hearings',
+  money: 'Money',
+  alert: 'Alerts',
 };
 
 const TodayScreen = () => {
-  const { neutral, branch: branchColors, semantic, typography, spacing } = useTheme();
-  const { brief, loading, error, reload } = useDailyBrief();
-  const { isSaved, toggleSave } = useSavedItems();
+  const { neutral, branch: branchColors, semantic } = useTheme();
   const navigation = useNavigation<NavigationProp>();
+  const { preferences } = useUserPreferences();
+  const feedOptions = useMemo(() => ({
+    followedBills: preferences.followedBills,
+    followedMembers: preferences.followedMembers,
+    followedTopics: preferences.followedTopics,
+    state: preferences.homeDistrict?.state,
+    district: preferences.homeDistrict?.district,
+    limit: 30,
+  }), [preferences]);
+  const { items, loading, error, reload } = useFeed('today', feedOptions);
 
-  const handleItemPress = useCallback((item: FeedItem) => {
+  const grouped = useMemo(() => {
+    return items.reduce<Record<string, FeedItem[]>>((acc, item) => {
+      const key = item.card_type ?? 'alert';
+      acc[key] = [...(acc[key] ?? []), item];
+      return acc;
+    }, {});
+  }, [items]);
+
+  const openItem = useCallback((item: FeedItem) => {
     navigation.navigate('UpdateDetail', { item });
   }, [navigation]);
 
-  const groupedUpdates = useMemo(() => {
-    if (!brief?.top_updates) return {};
-
-    const groups: Record<string, FeedItem[]> = {};
-    brief.top_updates.forEach(item => {
-      const branch = item.branch || 'legislative';
-      if (!groups[branch]) {
-        groups[branch] = [];
-      }
-      groups[branch].push(item);
-    });
-    return groups;
-  }, [brief]);
-
-  const urgentItems = useMemo(() => {
-    if (!brief?.highlights) return [];
-    return brief.highlights.filter(h =>
-      h.tags?.includes('urgent') || h.tags?.includes('breaking')
-    );
-  }, [brief]);
-
-  const content = useMemo(() => {
-    if (loading && !brief) {
-      return (
-        <View style={styles.loader}>
-          <ActivityIndicator size="large" color={branchColors.agency} />
-          <Text style={[styles.loaderText, { color: neutral.textPrimary }]}>
-            Preparing today's briefing...
-          </Text>
-        </View>
-      );
-    }
-
-    if (error) {
-      return (
-        <View style={styles.errorContainer}>
-          <Ionicons name="cloud-offline" size={48} color={semantic.error} />
-          <Text style={[styles.errorText, { color: semantic.error }]}>{error}</Text>
-          <Pressable style={[styles.retryButton, { backgroundColor: branchColors.agency }]} onPress={reload}>
-            <Text style={styles.retryText}>Try Again</Text>
-          </Pressable>
-        </View>
-      );
-    }
-
-    if (!brief) {
-      return (
-        <View style={styles.emptyContainer}>
-          <Ionicons name="newspaper-outline" size={48} color={neutral.textMuted} />
-          <Text style={[styles.emptyText, { color: neutral.textSecondary }]}>
-            No government actions to report yet today.
-          </Text>
-        </View>
-      );
-    }
-
-    return (
-      <View style={styles.contentWrapper}>
-        {/* Date Header */}
-        <View style={styles.dateHeader}>
-          <Ionicons name="sunny" size={24} color={branchColors.agency} />
-          <Text style={[styles.dateText, { color: neutral.textPrimary }]}>
-            {dayjs().format('dddd, MMMM D').toUpperCase()}
-          </Text>
-        </View>
-
-        {/* Hero Headline Card */}
-        <View style={[styles.heroCard, { backgroundColor: neutral.card }]}>
-          <View style={styles.heroLabelRow}>
-            <View style={styles.heroLabel}>
-              <Ionicons name="newspaper" size={16} color={branchColors.agency} />
-              <Text style={[styles.heroLabelText, { color: branchColors.agency }]}>
-                TOP STORY
-              </Text>
-            </View>
-            {brief.top_updates?.[0]?.branch && (
-              <View style={[
-                styles.heroBranchChip,
-                { backgroundColor: (branchColors[brief.top_updates[0].branch as Branch] || branchColors.agency) + '20' }
-              ]}>
-                <Text style={[
-                  styles.heroBranchText,
-                  { color: branchColors[brief.top_updates[0].branch as Branch] || branchColors.agency }
-                ]}>
-                  {brief.top_updates[0].branch.toUpperCase()}
-                </Text>
-              </View>
-            )}
-          </View>
-          <Text style={[styles.heroHeadline, { color: neutral.textPrimary }]}>
-            {brief.headline}
-          </Text>
-          <Text style={[styles.heroNarrative, { color: neutral.textSecondary }]}>
-            {brief.narrative}
-          </Text>
-        </View>
-
-        {/* Urgent Section */}
-        {urgentItems.length > 0 && (
-          <View style={styles.section}>
-            <View style={styles.sectionHeader}>
-              <View style={styles.sectionTitleRow}>
-                <Ionicons name="alert-circle" size={20} color={semantic.urgent} />
-                <Text style={[styles.sectionTitle, { color: semantic.urgent }]}>URGENT</Text>
-              </View>
-            </View>
-            {urgentItems.map((item, idx) => (
-              <Pressable
-                key={`urgent-${idx}`}
-                style={[styles.urgentCard, { backgroundColor: neutral.card, borderLeftColor: semantic.urgent }]}
-              >
-                <View style={styles.urgentDot} />
-                <Text style={[styles.urgentText, { color: neutral.textPrimary }]}>
-                  {item.headline}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
-        )}
-
-        {/* By Branch Section */}
-        <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={[styles.sectionDivider, { color: neutral.textMuted }]}>BY BRANCH</Text>
-          </View>
-
-          {Object.entries(groupedUpdates).map(([branchKey, items]) => {
-            const config = branchConfig[branchKey] || branchConfig.legislative;
-            const color = branchColors[branchKey as Branch] || branchColors.legislative;
-
-            return (
-              <View key={branchKey} style={styles.branchSection}>
-                <View style={styles.branchHeader}>
-                  <View style={[styles.branchIconContainer, { backgroundColor: color + '20' }]}>
-                    <Ionicons name={config.icon} size={20} color={color} />
-                  </View>
-                  <Text style={[styles.branchLabel, { color: neutral.textPrimary }]}>
-                    {config.label}
-                  </Text>
-                  <View style={styles.branchCount}>
-                    <Text style={[styles.branchCountText, { color: neutral.textMuted }]}>
-                      {items.length} update{items.length !== 1 ? 's' : ''}
-                    </Text>
-                    <Ionicons name="chevron-forward" size={16} color={neutral.textMuted} />
-                  </View>
-                </View>
-
-                {items.slice(0, 3).map(item => (
-                  <Pressable
-                    key={item.id}
-                    style={[styles.updateItem, { borderLeftColor: color }]}
-                    onPress={() => handleItemPress(item)}
-                  >
-                    <View style={styles.updateContent}>
-                      <Text style={[styles.updateHeadline, { color: neutral.textPrimary }]} numberOfLines={2}>
-                        {item.headline}
-                      </Text>
-                      <Text style={[styles.updateTime, { color: neutral.textMuted }]}>
-                        {dayjs(item.published_at).fromNow()}
-                      </Text>
-                    </View>
-                    <Pressable
-                      style={styles.saveButton}
-                      onPress={() => toggleSave(item)}
-                      hitSlop={8}
-                    >
-                      <Ionicons
-                        name={isSaved(item.id) ? 'bookmark' : 'bookmark-outline'}
-                        size={20}
-                        color={isSaved(item.id) ? branchColors.agency : neutral.textMuted}
-                      />
-                    </Pressable>
-                  </Pressable>
-                ))}
-              </View>
-            );
-          })}
-        </View>
-
-        {/* Highlights Section */}
-        {brief.highlights.length > 0 && (
-          <View style={styles.section}>
-            <View style={styles.sectionHeader}>
-              <Text style={[styles.sectionDivider, { color: neutral.textMuted }]}>HIGHLIGHTS</Text>
-            </View>
-
-            {brief.highlights.filter(h => !urgentItems.includes(h)).slice(0, 5).map((highlight, idx) => {
-              const color = branchColors[highlight.branch as Branch] || branchColors.legislative;
-              return (
-                <View
-                  key={`highlight-${idx}`}
-                  style={[styles.highlightCard, { backgroundColor: neutral.card }]}
-                >
-                  <View style={[styles.highlightBranchBar, { backgroundColor: color }]} />
-                  <View style={styles.highlightContent}>
-                    <View style={styles.highlightHeader}>
-                      <Text style={[styles.highlightBranch, { color }]}>
-                        {highlight.branch.toUpperCase()}
-                      </Text>
-                      <Text style={[styles.highlightTime, { color: neutral.textMuted }]}>
-                        {dayjs(highlight.published_at).format('h:mm A')}
-                      </Text>
-                    </View>
-                    <Text style={[styles.highlightHeadline, { color: neutral.textPrimary }]}>
-                      {highlight.headline}
-                    </Text>
-                    {highlight.summary && (
-                      <Text style={[styles.highlightSummary, { color: neutral.textSecondary }]} numberOfLines={2}>
-                        {highlight.summary}
-                      </Text>
-                    )}
-                  </View>
-                </View>
-              );
-            })}
-          </View>
-        )}
-
-        {/* Coming Up Section */}
-        {brief.upcoming_events && brief.upcoming_events.length > 0 && (
-          <View style={styles.section}>
-            <View style={styles.sectionHeader}>
-              <View style={styles.sectionTitleRow}>
-                <Ionicons name="calendar" size={18} color={branchColors.agency} />
-                <Text style={[styles.sectionTitle, { color: branchColors.agency }]}>COMING UP</Text>
-              </View>
-            </View>
-
-            {brief.upcoming_events.slice(0, 5).map((event, idx) => {
-              const color = branchColors[event.branch as Branch] || branchColors.executive;
-              return (
-                <View
-                  key={`upcoming-${idx}`}
-                  style={[styles.upcomingCard, { backgroundColor: neutral.card }]}
-                >
-                  <View style={[styles.upcomingDateBadge, { backgroundColor: branchColors.agency }]}>
-                    <Text style={styles.upcomingDateMonth}>
-                      {dayjs(event.event_date).format('MMM')}
-                    </Text>
-                    <Text style={styles.upcomingDateDay}>
-                      {dayjs(event.event_date).format('D')}
-                    </Text>
-                  </View>
-                  <View style={styles.upcomingContent}>
-                    <Text style={[styles.upcomingHeadline, { color: neutral.textPrimary }]} numberOfLines={2}>
-                      {event.headline}
-                    </Text>
-                    <View style={styles.upcomingMeta}>
-                      <View style={[styles.upcomingChip, { backgroundColor: color + '30' }]}>
-                        <Text style={[styles.upcomingChipText, { color }]}>
-                          {event.branch.toUpperCase()}
-                        </Text>
-                      </View>
-                      <Text style={[styles.upcomingType, { color: neutral.textMuted }]}>
-                        {event.event_type.replace('_', ' ')}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              );
-            })}
-          </View>
-        )}
-      </View>
-    );
-  }, [brief, error, loading, groupedUpdates, urgentItems, branchColors, neutral, semantic, isSaved, toggleSave, handleItemPress, reload]);
+  const topItem = items[0];
 
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: neutral.background }]}
       contentContainerStyle={styles.scrollContent}
       refreshControl={
-        <RefreshControl
-          refreshing={loading}
-          onRefresh={reload}
-          tintColor={branchColors.agency}
-        />
+        <RefreshControl refreshing={loading} onRefresh={reload} tintColor={branchColors.agency} />
       }
     >
-      {content}
+      <View style={styles.header}>
+        <Text style={[styles.eyebrow, { color: neutral.textMuted }]}>
+          {dayjs().format('dddd, MMMM D').toUpperCase()}
+        </Text>
+        <Text style={[styles.title, { color: neutral.textPrimary }]}>Today</Text>
+      </View>
+
+      {loading && items.length === 0 && (
+        <View style={styles.stateBlock}>
+          <ActivityIndicator size="large" color={branchColors.agency} />
+          <Text style={[styles.stateText, { color: neutral.textSecondary }]}>
+            Loading primary-source events...
+          </Text>
+        </View>
+      )}
+
+      {error && (
+        <View style={[styles.notice, { borderColor: semantic.warning }]}>
+          <Ionicons name="cloud-offline-outline" size={20} color={semantic.warning} />
+          <Text style={[styles.noticeText, { color: neutral.textSecondary }]}>{error}</Text>
+        </View>
+      )}
+
+      {!loading && items.length === 0 && (
+        <View style={styles.stateBlock}>
+          <Ionicons name="newspaper-outline" size={36} color={neutral.textMuted} />
+          <Text style={[styles.stateText, { color: neutral.textSecondary }]}>
+            No source-backed events are available for today yet.
+          </Text>
+        </View>
+      )}
+
+      {topItem && (
+        <Pressable
+          style={[styles.topStory, { backgroundColor: neutral.card, borderColor: neutral.divider }]}
+          onPress={() => openItem(topItem)}
+        >
+          <View style={styles.topRow}>
+            <Text style={[styles.sectionLabel, { color: branchColors.agency }]}>TOP RANKED EVENT</Text>
+            <Text style={[styles.scoreText, { color: neutral.textMuted }]}>
+              {Math.round(topItem.rank_context?.score ?? 0)}
+            </Text>
+          </View>
+          <Text style={[styles.topHeadline, { color: neutral.textPrimary }]}>{topItem.headline}</Text>
+          <Text style={[styles.summary, { color: neutral.textSecondary }]}>
+            {topItem.summary ?? 'Official summary has not been published yet.'}
+          </Text>
+          <RankReasons item={topItem} />
+          <SourceTrailPreview item={topItem} />
+        </Pressable>
+      )}
+
+      {cardTypeOrder.map(cardType => {
+        const sectionItems = grouped[cardType] ?? [];
+        if (sectionItems.length === 0) return null;
+
+        return (
+          <View key={cardType} style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>
+                {cardTypeLabels[cardType]}
+              </Text>
+              <Text style={[styles.sectionCount, { color: neutral.textMuted }]}>
+                {sectionItems.length}
+              </Text>
+            </View>
+
+            {sectionItems.map(item => (
+              <Pressable
+                key={item.id}
+                style={[styles.eventRow, { borderColor: neutral.divider, backgroundColor: neutral.card }]}
+                onPress={() => openItem(item)}
+              >
+                <View style={styles.eventHeader}>
+                  <Text style={[styles.eventType, { color: branchColors[item.branch] ?? branchColors.legislative }]}>
+                    {(item.card_type ?? 'event').toUpperCase()}
+                  </Text>
+                  <Text style={[styles.eventTime, { color: neutral.textMuted }]}>
+                    {dayjs(item.published_at).fromNow()}
+                  </Text>
+                </View>
+                <Text style={[styles.eventHeadline, { color: neutral.textPrimary }]} numberOfLines={2}>
+                  {item.headline}
+                </Text>
+                {item.rank_context?.reasons?.[0] && (
+                  <Text style={[styles.reasonText, { color: neutral.textSecondary }]} numberOfLines={2}>
+                    {item.rank_context.reasons[0]}
+                  </Text>
+                )}
+                <SourceTrailPreview item={item} compact />
+              </Pressable>
+            ))}
+          </View>
+        );
+      })}
     </ScrollView>
+  );
+};
+
+const RankReasons = ({ item }: { item: FeedItem }) => {
+  const { neutral } = useTheme();
+  const reasons = item.rank_context?.reasons ?? [];
+  if (reasons.length === 0) return null;
+
+  return (
+    <View style={styles.reasonList}>
+      {reasons.slice(0, 3).map(reason => (
+        <View key={reason} style={styles.reasonRow}>
+          <Ionicons name="information-circle-outline" size={16} color={neutral.textMuted} />
+          <Text style={[styles.reasonText, { color: neutral.textSecondary }]}>{reason}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const SourceTrailPreview = ({ item, compact = false }: { item: FeedItem; compact?: boolean }) => {
+  const { neutral, branch } = useTheme();
+  const firstSource = item.source_trail?.[0];
+  if (!firstSource && !item.source_trail_note) return null;
+
+  return (
+    <View style={compact ? styles.sourceCompact : styles.sourceBox}>
+      <Ionicons
+        name={firstSource ? 'link-outline' : 'alert-circle-outline'}
+        size={16}
+        color={firstSource ? branch.agency : neutral.textMuted}
+      />
+      <Text style={[styles.sourceText, { color: neutral.textSecondary }]} numberOfLines={compact ? 1 : 2}>
+        {firstSource ? `${firstSource.label} · ${firstSource.source}` : item.source_trail_note}
+      </Text>
+    </View>
   );
 };
 
@@ -329,285 +206,139 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    padding: 16,
     paddingTop: 60,
-    paddingBottom: 100,
-  },
-  loader: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 12,
-    paddingTop: 120,
-  },
-  loaderText: {
-    fontSize: 16,
-  },
-  errorContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingBottom: 120,
     gap: 16,
-    paddingTop: 120,
   },
-  errorText: {
-    fontSize: 16,
-    textAlign: 'center',
+  header: {
+    gap: 4,
   },
-  retryButton: {
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 999,
-  },
-  retryText: {
-    color: '#0B1D3A',
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  emptyContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 12,
-    paddingTop: 120,
-  },
-  emptyText: {
-    fontSize: 16,
-    textAlign: 'center',
-  },
-  contentWrapper: {
-    gap: 24,
-  },
-  dateHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  dateText: {
-    fontSize: 14,
-    fontWeight: '700',
-    letterSpacing: 1,
-  },
-  heroCard: {
-    borderRadius: 20,
-    padding: 20,
-    gap: 12,
-  },
-  heroLabelRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  heroLabel: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  heroLabelText: {
+  eyebrow: {
     fontSize: 12,
     fontWeight: '700',
-    letterSpacing: 1,
   },
-  heroBranchChip: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 999,
-  },
-  heroBranchText: {
-    fontSize: 10,
-    fontWeight: '700',
-    letterSpacing: 0.5,
-  },
-  heroHeadline: {
-    fontSize: 24,
+  title: {
+    fontSize: 34,
     fontWeight: '800',
-    lineHeight: 30,
   },
-  heroNarrative: {
-    fontSize: 16,
-    lineHeight: 24,
+  stateBlock: {
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 48,
+  },
+  stateText: {
+    fontSize: 15,
+    textAlign: 'center',
+  },
+  notice: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+  },
+  noticeText: {
+    flex: 1,
+    fontSize: 14,
+  },
+  topStory: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 16,
+    gap: 10,
+  },
+  topRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  scoreText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  topHeadline: {
+    fontSize: 22,
+    lineHeight: 28,
+    fontWeight: '800',
+  },
+  summary: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  reasonList: {
+    gap: 6,
+  },
+  reasonRow: {
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'flex-start',
+  },
+  reasonText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  sourceBox: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: 'rgba(148, 163, 184, 0.35)',
+    paddingTop: 10,
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+  },
+  sourceCompact: {
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+  },
+  sourceText: {
+    flex: 1,
+    fontSize: 12,
   },
   section: {
-    gap: 12,
+    gap: 10,
   },
   sectionHeader: {
     flexDirection: 'row',
-    alignItems: 'center',
     justifyContent: 'space-between',
-  },
-  sectionTitleRow: {
-    flexDirection: 'row',
     alignItems: 'center',
-    gap: 6,
   },
   sectionTitle: {
-    fontSize: 14,
-    fontWeight: '700',
-    letterSpacing: 0.5,
-  },
-  sectionDivider: {
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.5,
-  },
-  urgentCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 16,
-    borderRadius: 12,
-    borderLeftWidth: 4,
-    gap: 12,
-  },
-  urgentDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: '#EF4444',
-  },
-  urgentText: {
-    flex: 1,
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  branchSection: {
-    gap: 8,
-  },
-  branchHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    paddingVertical: 8,
-  },
-  branchIconContainer: {
-    width: 36,
-    height: 36,
-    borderRadius: 10,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  branchLabel: {
-    fontSize: 16,
-    fontWeight: '600',
-    flex: 1,
-  },
-  branchCount: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-  },
-  branchCountText: {
-    fontSize: 14,
-  },
-  updateItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingLeft: 16,
-    paddingVertical: 12,
-    marginLeft: 18,
-    borderLeftWidth: 2,
-    gap: 12,
-  },
-  updateContent: {
-    flex: 1,
-    gap: 4,
-  },
-  updateHeadline: {
-    fontSize: 15,
-    fontWeight: '500',
-    lineHeight: 20,
-  },
-  updateTime: {
-    fontSize: 12,
-  },
-  saveButton: {
-    padding: 4,
-  },
-  highlightCard: {
-    flexDirection: 'row',
-    borderRadius: 16,
-    overflow: 'hidden',
-  },
-  highlightBranchBar: {
-    width: 4,
-  },
-  highlightContent: {
-    flex: 1,
-    padding: 16,
-    gap: 8,
-  },
-  highlightHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  highlightBranch: {
-    fontSize: 11,
-    fontWeight: '700',
-    letterSpacing: 0.5,
-  },
-  highlightTime: {
-    fontSize: 12,
-  },
-  highlightHeadline: {
-    fontSize: 16,
-    fontWeight: '600',
-    lineHeight: 22,
-  },
-  highlightSummary: {
-    fontSize: 14,
-    lineHeight: 20,
-  },
-  upcomingCard: {
-    flexDirection: 'row',
-    borderRadius: 16,
-    padding: 12,
-    gap: 12,
-    alignItems: 'center',
-  },
-  upcomingDateBadge: {
-    width: 52,
-    height: 52,
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  upcomingDateMonth: {
-    color: '#0B1D3A',
-    fontSize: 10,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-  },
-  upcomingDateDay: {
-    color: '#0B1D3A',
     fontSize: 18,
     fontWeight: '800',
   },
-  upcomingContent: {
-    flex: 1,
-    gap: 6,
-  },
-  upcomingHeadline: {
-    fontSize: 14,
-    fontWeight: '600',
-    lineHeight: 18,
-  },
-  upcomingMeta: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  upcomingChip: {
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 999,
-  },
-  upcomingChipText: {
-    fontSize: 10,
+  sectionCount: {
+    fontSize: 13,
     fontWeight: '700',
   },
-  upcomingType: {
+  eventRow: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 14,
+    gap: 8,
+  },
+  eventHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  eventType: {
+    fontSize: 11,
+    fontWeight: '800',
+  },
+  eventTime: {
     fontSize: 12,
-    textTransform: 'capitalize',
+  },
+  eventHeadline: {
+    fontSize: 16,
+    lineHeight: 21,
+    fontWeight: '700',
   },
 });
 

--- a/frontend/src/features/updateDetail/screens/UpdateDetailScreen.tsx
+++ b/frontend/src/features/updateDetail/screens/UpdateDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Linking,
   Pressable,
@@ -6,227 +6,554 @@ import {
   Share,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-import { useTheme } from '@theme/ThemeProvider';
-import { useSavedItems } from '../../../context/SavedItemsContext';
+import {
+  BillDetail,
+  Branch,
+  FeedItem,
+  HearingDetail,
+  SourceTrailItem,
+  VoteDetail,
+  VotePosition,
+} from '@features/feed/types';
+import BillStatusTracker from '@features/updateDetail/components/BillStatusTracker';
+import { useSavedItems } from '@context/SavedItemsContext';
+import { useUserPreferences, UserBillPosition } from '@context/UserPreferencesContext';
 import { RootStackParamList } from '@navigation/RootNavigator';
-import { Branch } from '@features/feed/types';
+import { useTheme } from '@theme/ThemeProvider';
 import dayjs from '@utils/dayjs';
-import BillStatusTracker from '../components/BillStatusTracker';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'UpdateDetail'>;
 
-const branchConfig: Record<string, { icon: keyof typeof Ionicons.glyphMap; label: string }> = {
-  legislative: { icon: 'business', label: 'Legislative' },
-  house: { icon: 'business', label: 'House' },
-  senate: { icon: 'business', label: 'Senate' },
-  executive: { icon: 'document-text', label: 'Executive' },
-  judicial: { icon: 'scale', label: 'Judicial' },
-  agency: { icon: 'grid', label: 'Agency' },
-};
+const positionOptions: { value: UserBillPosition['position']; label: string }[] = [
+  { value: 'yea', label: 'Yea' },
+  { value: 'nay', label: 'Nay' },
+  { value: 'present', label: 'Present' },
+  { value: 'abstain', label: 'Abstain' },
+  { value: 'undecided', label: 'Undecided' },
+];
 
 const UpdateDetailScreen = ({ route, navigation }: Props) => {
   const { item } = route.params;
-  const { neutral, branch: branchColors, semantic, spacing } = useTheme();
+  const { neutral, branch: branchColors } = useTheme();
   const { isSaved, toggleSave } = useSavedItems();
-
-  const branchColor = branchColors[item.branch as Branch] || branchColors.legislative;
-  const config = branchConfig[item.branch] || branchConfig.legislative;
+  const [voteSearch, setVoteSearch] = useState('');
   const saved = isSaved(item.id);
-
-  // Determine if this is a bill (for showing status tracker)
-  const isBill = useMemo(() => {
-    const lowerHeadline = item.headline.toLowerCase();
-    const lowerTags = item.tags.map(t => t.toLowerCase());
-    return (
-      lowerHeadline.includes('bill') ||
-      lowerHeadline.includes('h.r.') ||
-      lowerHeadline.includes('s.') ||
-      lowerHeadline.includes('act') ||
-      lowerTags.includes('bill') ||
-      lowerTags.includes('legislation')
-    );
-  }, [item]);
-
-  // Extract bill status from metadata if available
-  const billStatus = useMemo(() => {
-    if (!isBill) return null;
-
-    // Default to introduced status, can be enhanced with real data
-    const status = (item.metadata?.status as string) || 'introduced';
-    const statusMap: Record<string, number> = {
-      'introduced': 0,
-      'committee': 1,
-      'floor': 2,
-      'passed_house': 2,
-      'passed_senate': 2,
-      'other_chamber': 3,
-      'conference': 4,
-      'president': 5,
-      'signed': 6,
-      'vetoed': 6,
-    };
-    return statusMap[status] ?? 0;
-  }, [isBill, item.metadata]);
+  const branchColor = branchColors[item.branch as Branch] || branchColors.legislative;
 
   const handleShare = async () => {
-    try {
-      await Share.share({
-        message: `${item.headline}\n\n${item.summary}${item.url ? `\n\nRead more: ${item.url}` : ''}`,
-        title: item.headline,
-      });
-    } catch (error) {
-      console.error('Error sharing:', error);
-    }
-  };
-
-  const handleOpenUrl = () => {
-    if (item.url) {
-      Linking.openURL(item.url);
-    }
+    await Share.share({
+      message: `${item.headline}\n\n${item.summary ?? ''}${item.url ? `\n\nSource: ${item.url}` : ''}`,
+      title: item.headline,
+    });
   };
 
   return (
     <View style={[styles.container, { backgroundColor: neutral.background }]}>
-      {/* Header */}
       <View style={[styles.header, { borderBottomColor: neutral.divider }]}>
-        <Pressable
-          style={styles.backButton}
-          onPress={() => navigation.goBack()}
-          hitSlop={12}
-        >
+        <Pressable style={styles.iconButton} onPress={() => navigation.goBack()} hitSlop={12}>
           <Ionicons name="arrow-back" size={24} color={neutral.textPrimary} />
         </Pressable>
         <View style={styles.headerActions}>
-          <Pressable
-            style={styles.headerButton}
-            onPress={() => toggleSave(item)}
-            hitSlop={8}
-          >
+          <Pressable style={styles.iconButton} onPress={() => toggleSave(item)} hitSlop={8}>
             <Ionicons
               name={saved ? 'bookmark' : 'bookmark-outline'}
-              size={24}
+              size={23}
               color={saved ? branchColors.agency : neutral.textPrimary}
             />
           </Pressable>
-          <Pressable
-            style={styles.headerButton}
-            onPress={handleShare}
-            hitSlop={8}
-          >
-            <Ionicons name="share-outline" size={24} color={neutral.textPrimary} />
+          <Pressable style={styles.iconButton} onPress={handleShare} hitSlop={8}>
+            <Ionicons name="share-outline" size={23} color={neutral.textPrimary} />
           </Pressable>
         </View>
       </View>
 
-      <ScrollView
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
-      >
-        {/* Branch Badge */}
-        <View style={styles.branchRow}>
-          <View style={[styles.branchBadge, { backgroundColor: branchColor + '20' }]}>
-            <Ionicons name={config.icon} size={16} color={branchColor} />
-            <Text style={[styles.branchText, { color: branchColor }]}>
-              {config.label.toUpperCase()}
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+        <View style={styles.kickerRow}>
+          <View style={[styles.kicker, { borderColor: branchColor }]}>
+            <Text style={[styles.kickerText, { color: branchColor }]}>
+              {(item.card_type ?? item.branch).toUpperCase()}
             </Text>
           </View>
-        </View>
-
-        {/* Main Content */}
-        <Text style={[styles.headline, { color: neutral.textPrimary }]}>
-          {item.headline}
-        </Text>
-
-        <View style={styles.metaRow}>
-          <Text style={[styles.source, { color: neutral.textMuted }]}>
-            {item.source.toUpperCase()}
-          </Text>
-          <Text style={[styles.metaDot, { color: neutral.textMuted }]}>•</Text>
-          <Text style={[styles.date, { color: neutral.textMuted }]}>
+          <Text style={[styles.dateText, { color: neutral.textMuted }]}>
             {dayjs(item.published_at).format('MMM D, YYYY h:mm A')}
           </Text>
         </View>
 
-        {/* Bill Status Tracker */}
-        {isBill && billStatus !== null && (
-          <View style={styles.statusSection}>
-            <Text style={[styles.sectionLabel, { color: neutral.textMuted }]}>STATUS</Text>
-            <BillStatusTracker currentStep={billStatus} />
-          </View>
+        <Text style={[styles.headline, { color: neutral.textPrimary }]}>{item.headline}</Text>
+        <Text style={[styles.summary, { color: neutral.textSecondary }]}>
+          {item.summary ?? 'Official summary has not been published yet.'}
+        </Text>
+
+        <RankContext item={item} />
+        <SourceTrail sources={item.source_trail ?? []} note={item.source_trail_note} />
+
+        {item.detail?.bill ? (
+          <BillDetailView item={item} bill={item.detail.bill} />
+        ) : item.detail?.vote ? (
+          <VoteDetailView vote={item.detail.vote} search={voteSearch} onSearchChange={setVoteSearch} />
+        ) : item.detail?.hearing ? (
+          <HearingDetailView hearing={item.detail.hearing} />
+        ) : (
+          <GenericDetail item={item} />
         )}
-
-        {/* Summary */}
-        <View style={styles.summarySection}>
-          <Text style={[styles.sectionLabel, { color: neutral.textMuted }]}>SUMMARY</Text>
-          <Text style={[styles.summary, { color: neutral.textSecondary }]}>
-            {item.summary}
-          </Text>
-        </View>
-
-        {/* Tags */}
-        {item.tags.length > 0 && (
-          <View style={styles.tagsSection}>
-            <Text style={[styles.sectionLabel, { color: neutral.textMuted }]}>TOPICS</Text>
-            <View style={styles.tagsContainer}>
-              {item.tags.map(tag => (
-                <View
-                  key={tag}
-                  style={[styles.tag, { backgroundColor: neutral.card }]}
-                >
-                  <Text style={[styles.tagText, { color: neutral.textPrimary }]}>{tag}</Text>
-                </View>
-              ))}
-            </View>
-          </View>
-        )}
-
-        {/* Timeline (Placeholder for future enhancement) */}
-        <View style={styles.timelineSection}>
-          <Text style={[styles.sectionLabel, { color: neutral.textMuted }]}>TIMELINE</Text>
-          <View style={[styles.timelineItem, { borderLeftColor: branchColor }]}>
-            <Text style={[styles.timelineDate, { color: neutral.textMuted }]}>
-              {dayjs(item.published_at).format('MMM D')}
-            </Text>
-            <Text style={[styles.timelineEvent, { color: neutral.textPrimary }]}>
-              Published
-            </Text>
-          </View>
-        </View>
-
-        {/* Action Buttons */}
-        <View style={styles.actionsSection}>
-          {item.url && (
-            <Pressable
-              style={[styles.primaryButton, { backgroundColor: branchColor }]}
-              onPress={handleOpenUrl}
-            >
-              <Ionicons name="open-outline" size={20} color="#FFFFFF" />
-              <Text style={styles.primaryButtonText}>View Full Text</Text>
-            </Pressable>
-          )}
-
-          <Pressable
-            style={[styles.secondaryButton, { borderColor: branchColor }]}
-            onPress={() => toggleSave(item)}
-          >
-            <Ionicons
-              name={saved ? 'bookmark' : 'bookmark-outline'}
-              size={20}
-              color={branchColor}
-            />
-            <Text style={[styles.secondaryButtonText, { color: branchColor }]}>
-              {saved ? 'Saved' : 'Track This Update'}
-            </Text>
-          </Pressable>
-        </View>
       </ScrollView>
     </View>
   );
+};
+
+const BillDetailView = ({ item, bill }: { item: FeedItem; bill: BillDetail }) => {
+  const { neutral, branch } = useTheme();
+  const {
+    preferences,
+    followBill,
+    unfollowBill,
+    setBillPosition,
+    clearBillPosition,
+  } = useUserPreferences();
+  const followed = preferences.followedBills.includes(bill.canonical_id);
+  const savedPosition = preferences.billPositions[bill.canonical_id]?.position;
+  const statusStep = billStatusStep(bill.status);
+
+  return (
+    <View style={styles.detailStack}>
+      <ActionRow
+        primaryLabel={followed ? 'Following Bill' : 'Follow Bill'}
+        onPrimary={() => followed ? unfollowBill(bill.canonical_id) : followBill(bill.canonical_id)}
+        sourceUrl={bill.source_url ?? item.url}
+      />
+
+      <Section title="Status">
+        <Text style={[styles.bodyText, { color: neutral.textSecondary }]}>{bill.status}</Text>
+        <BillStatusTracker currentStep={statusStep} />
+      </Section>
+
+      {bill.vote_eligible && (
+        <Section title="Your Position">
+          <Text style={[styles.bodyText, { color: neutral.textSecondary }]}>
+            {bill.user_position_prompt}
+          </Text>
+          <View style={styles.positionGrid}>
+            {positionOptions.map(option => {
+              const active = savedPosition === option.value;
+              return (
+                <Pressable
+                  key={option.value}
+                  style={[
+                    styles.positionButton,
+                    {
+                      borderColor: active ? branch.agency : neutral.divider,
+                      backgroundColor: active ? branch.agency : neutral.card,
+                    },
+                  ]}
+                  onPress={() => setBillPosition(bill.canonical_id, option.value)}
+                >
+                  <Text style={[styles.positionText, { color: active ? '#FFFFFF' : neutral.textPrimary }]}>
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          {savedPosition && (
+            <Pressable onPress={() => clearBillPosition(bill.canonical_id)}>
+              <Text style={[styles.linkText, { color: branch.agency }]}>Clear personal position</Text>
+            </Pressable>
+          )}
+        </Section>
+      )}
+
+      <RecordList title="Sponsors" records={bill.sponsors} emptyText="Official sponsor data is not published yet." />
+      <RecordList title="Cosponsors" records={bill.cosponsors} emptyText="Official cosponsor data is not published yet." />
+      <RecordList title="Committees" records={bill.committees} emptyText={bill.unavailable.committees ?? 'No committees are linked.'} />
+      <Section title="Lifecycle">
+        {bill.timeline.length === 0 ? (
+          <Unavailable text="No official lifecycle actions are published yet." />
+        ) : (
+          bill.timeline.map(action => (
+            <View key={action.id} style={[styles.timelineRow, { borderLeftColor: branch.legislative }]}>
+              <Text style={[styles.metaText, { color: neutral.textMuted }]}>
+                {action.acted_at ? dayjs(action.acted_at).format('MMM D, YYYY') : 'Date unavailable'}
+              </Text>
+              <Text style={[styles.bodyTextStrong, { color: neutral.textPrimary }]}>{action.text}</Text>
+              {action.source_url && <SourceLink url={action.source_url} label="Official action" />}
+            </View>
+          ))
+        )}
+      </Section>
+      <RecordList title="Text Versions" records={bill.text_versions} emptyText={bill.unavailable.text_versions ?? 'No official text versions are published yet.'} />
+      <RecordList title="Amendments" records={bill.amendments} emptyText="No official amendments are published yet." />
+      <RecordList title="Votes" records={bill.votes} emptyText={bill.unavailable.votes ?? 'No votes are linked yet.'} />
+      <RecordList title="CBO And CRS" records={[...bill.cbo_cost_estimates, ...bill.crs_reports]} emptyText="No CBO estimate or CRS report is published yet." />
+      <RecordList title="Related Bills" records={bill.related_bills} emptyText="No related bills are published yet." />
+    </View>
+  );
+};
+
+const VoteDetailView = ({
+  vote,
+  search,
+  onSearchChange,
+}: {
+  vote: VoteDetail;
+  search: string;
+  onSearchChange: (value: string) => void;
+}) => {
+  const { neutral, branch } = useTheme();
+  const filteredPositions = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return vote.positions;
+    return vote.positions.filter(position => (
+      position.member_name.toLowerCase().includes(query) ||
+      (position.party ?? '').toLowerCase().includes(query) ||
+      position.position.toLowerCase().includes(query) ||
+      (position.state ?? '').toLowerCase().includes(query)
+    ));
+  }, [search, vote.positions]);
+
+  return (
+    <View style={styles.detailStack}>
+      <ActionRow sourceUrl={vote.source_url} />
+      <Section title="Roll Call">
+        <FactGrid facts={[
+          ['Chamber', vote.chamber],
+          ['Roll', vote.roll_number],
+          ['Result', vote.result ?? 'Unavailable'],
+          ['Margin', vote.margin ?? 'Unavailable'],
+        ]} />
+        <Text style={[styles.bodyTextStrong, { color: neutral.textPrimary }]}>{vote.question}</Text>
+      </Section>
+
+      <Section title="Totals">
+        <RecordPills values={vote.totals} />
+      </Section>
+
+      <Section title="Party Split">
+        <RecordPills values={vote.party_split} />
+      </Section>
+
+      <Section title="Local Representatives">
+        {vote.local_representative_positions.length === 0 ? (
+          <Unavailable text={vote.unavailable.local_representatives ?? 'No local representative match is available.'} />
+        ) : (
+          vote.local_representative_positions.map(position => (
+            <PositionRow key={position.member_identifier} position={position} highlight />
+          ))
+        )}
+      </Section>
+
+      {vote.linked_bill && (
+        <Section title="Linked Bill">
+          <Text style={[styles.bodyTextStrong, { color: neutral.textPrimary }]}>
+            {recordLabel(vote.linked_bill)}
+          </Text>
+        </Section>
+      )}
+
+      <Section title="Member Positions">
+        <TextInput
+          value={search}
+          onChangeText={onSearchChange}
+          placeholder="Search by member, party, state, or position"
+          placeholderTextColor={neutral.textMuted}
+          style={[styles.searchInput, { color: neutral.textPrimary, borderColor: neutral.divider }]}
+        />
+        {filteredPositions.length === 0 ? (
+          <Unavailable text={vote.unavailable.member_positions ?? 'No matching positions.'} />
+        ) : (
+          filteredPositions.slice(0, 80).map(position => (
+            <PositionRow key={position.member_identifier} position={position} />
+          ))
+        )}
+        {filteredPositions.length > 80 && (
+          <Text style={[styles.metaText, { color: branch.agency }]}>
+            Showing first 80 matching positions.
+          </Text>
+        )}
+      </Section>
+    </View>
+  );
+};
+
+const HearingDetailView = ({ hearing }: { hearing: HearingDetail }) => {
+  const { neutral, branch } = useTheme();
+  const { preferences, followCommittee, unfollowCommittee } = useUserPreferences();
+  const committeeCode = getRecordString(hearing.committee, 'committee_code');
+  const committeeName = getRecordString(hearing.committee, 'name');
+  const followed = committeeCode ? preferences.followedCommittees.includes(committeeCode) : false;
+
+  return (
+    <View style={styles.detailStack}>
+      <ActionRow
+        primaryLabel={committeeCode ? (followed ? 'Following Committee' : 'Follow Committee') : undefined}
+        onPrimary={committeeCode ? () => followed ? unfollowCommittee(committeeCode) : followCommittee(committeeCode) : undefined}
+        sourceUrl={hearing.source_url}
+      />
+      <Section title="Schedule">
+        <FactGrid facts={[
+          ['Status', hearing.status ?? 'Unavailable'],
+          ['Type', hearing.meeting_type ?? 'Unavailable'],
+          ['When', hearing.scheduled_at ? dayjs(hearing.scheduled_at).format('MMM D, YYYY h:mm A') : 'Unavailable'],
+          ['Location', hearing.location ?? 'Unavailable'],
+        ]} />
+      </Section>
+      <Section title="Committee">
+        {committeeName ? (
+          <>
+            <Text style={[styles.bodyTextStrong, { color: neutral.textPrimary }]}>{committeeName}</Text>
+            {getRecordString(hearing.committee, 'jurisdiction') && (
+              <Text style={[styles.bodyText, { color: neutral.textSecondary }]}>
+                {getRecordString(hearing.committee, 'jurisdiction')}
+              </Text>
+            )}
+          </>
+        ) : (
+          <Unavailable text="Official committee details are not published yet." />
+        )}
+      </Section>
+      <RecordList title="Witnesses" records={hearing.witnesses} emptyText={hearing.unavailable.witnesses ?? 'Witnesses are not published yet.'} />
+      <RecordList title="Related Bills" records={hearing.related_bills} emptyText="No related bills are published yet." />
+      <RecordList title="Video" records={hearing.videos} emptyText={hearing.unavailable.videos ?? 'Official video is not published yet.'} />
+      <RecordList title="Transcript" records={hearing.transcripts} emptyText={hearing.unavailable.transcripts ?? 'Official transcript is not published yet.'} />
+      {hearing.alert_affordance && (
+        <View style={[styles.notice, { borderColor: branch.agency }]}>
+          <Ionicons name="notifications-outline" size={18} color={branch.agency} />
+          <Text style={[styles.bodyText, { color: neutral.textSecondary }]}>{hearing.alert_affordance}</Text>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const GenericDetail = ({ item }: { item: FeedItem }) => {
+  const { neutral } = useTheme();
+  return (
+    <View style={styles.detailStack}>
+      <Section title="Summary">
+        <Text style={[styles.bodyText, { color: neutral.textSecondary }]}>
+          {item.full_text ?? item.summary ?? 'No additional detail is available yet.'}
+        </Text>
+      </Section>
+      {item.url && <ActionRow sourceUrl={item.url} />}
+    </View>
+  );
+};
+
+const RankContext = ({ item }: { item: FeedItem }) => {
+  const { neutral } = useTheme();
+  const factors = item.rank_context?.factors;
+  if (!factors) return null;
+  return (
+    <Section title="Why This Is Ranked Here">
+      <View style={styles.factorGrid}>
+        {Object.entries(factors).map(([key, value]) => (
+          <View key={key} style={[styles.factor, { borderColor: neutral.divider }]}>
+            <Text style={[styles.factorLabel, { color: neutral.textMuted }]}>{key.replace(/_/g, ' ')}</Text>
+            <Text style={[styles.factorValue, { color: neutral.textPrimary }]}>{Math.round(value)}</Text>
+          </View>
+        ))}
+      </View>
+    </Section>
+  );
+};
+
+const SourceTrail = ({ sources, note }: { sources: SourceTrailItem[]; note?: string | null }) => (
+  <Section title="Source Trail">
+    {sources.length === 0 ? (
+      <Unavailable text={note ?? 'Official sources are not attached yet.'} />
+    ) : (
+      sources.map(source => (
+        <SourceLink key={`${source.source}-${source.url}`} url={source.url} label={`${source.label} · ${source.source}`} />
+      ))
+    )}
+  </Section>
+);
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => {
+  const { neutral } = useTheme();
+  return (
+    <View style={[styles.section, { borderColor: neutral.divider }]}>
+      <Text style={[styles.sectionTitle, { color: neutral.textMuted }]}>{title.toUpperCase()}</Text>
+      {children}
+    </View>
+  );
+};
+
+const ActionRow = ({
+  primaryLabel,
+  onPrimary,
+  sourceUrl,
+}: {
+  primaryLabel?: string;
+  onPrimary?: () => void;
+  sourceUrl?: string | null;
+}) => {
+  const { branch } = useTheme();
+  if (!primaryLabel && !sourceUrl) return null;
+  return (
+    <View style={styles.actionRow}>
+      {primaryLabel && onPrimary && (
+        <Pressable style={[styles.primaryButton, { backgroundColor: branch.agency }]} onPress={onPrimary}>
+          <Text style={styles.primaryButtonText}>{primaryLabel}</Text>
+        </Pressable>
+      )}
+      {sourceUrl && (
+        <Pressable style={[styles.secondaryButton, { borderColor: branch.agency }]} onPress={() => Linking.openURL(sourceUrl)}>
+          <Ionicons name="open-outline" size={18} color={branch.agency} />
+          <Text style={[styles.secondaryButtonText, { color: branch.agency }]}>Official Source</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+};
+
+const SourceLink = ({ url, label }: { url: string; label: string }) => {
+  const { branch } = useTheme();
+  return (
+    <Pressable style={styles.sourceLink} onPress={() => Linking.openURL(url)}>
+      <Ionicons name="link-outline" size={17} color={branch.agency} />
+      <Text style={[styles.linkText, { color: branch.agency }]}>{label}</Text>
+    </Pressable>
+  );
+};
+
+const RecordList = ({
+  title,
+  records,
+  emptyText,
+}: {
+  title: string;
+  records: Record<string, unknown>[];
+  emptyText: string;
+}) => (
+  <Section title={title}>
+    {records.length === 0 ? (
+      <Unavailable text={emptyText} />
+    ) : (
+      records.slice(0, 12).map((record, index) => (
+        <RecordRow key={`${title}-${index}`} record={record} />
+      ))
+    )}
+  </Section>
+);
+
+const RecordRow = ({ record }: { record: Record<string, unknown> }) => {
+  const { neutral } = useTheme();
+  return (
+    <View style={[styles.recordRow, { borderColor: neutral.divider }]}>
+      <Text style={[styles.bodyTextStrong, { color: neutral.textPrimary }]}>{recordLabel(record)}</Text>
+      {recordMeta(record) && (
+        <Text style={[styles.metaText, { color: neutral.textMuted }]}>{recordMeta(record)}</Text>
+      )}
+      {getRecordString(record, 'source_url') && (
+        <SourceLink url={getRecordString(record, 'source_url') ?? ''} label="Official link" />
+      )}
+    </View>
+  );
+};
+
+const PositionRow = ({ position, highlight = false }: { position: VotePosition; highlight?: boolean }) => {
+  const { neutral, branch } = useTheme();
+  return (
+    <View style={[styles.positionRow, { borderColor: highlight ? branch.agency : neutral.divider }]}>
+      <View style={styles.positionTextBlock}>
+        <Text style={[styles.bodyTextStrong, { color: neutral.textPrimary }]}>{position.member_name}</Text>
+        <Text style={[styles.metaText, { color: neutral.textMuted }]}>
+          {[position.party, position.state, position.district ? `District ${position.district}` : null].filter(Boolean).join(' · ')}
+        </Text>
+      </View>
+      <Text style={[styles.voteBadge, { color: branch.agency }]}>{position.position.toUpperCase()}</Text>
+    </View>
+  );
+};
+
+const FactGrid = ({ facts }: { facts: [string, string][] }) => {
+  const { neutral } = useTheme();
+  return (
+    <View style={styles.factGrid}>
+      {facts.map(([label, value]) => (
+        <View key={label} style={[styles.fact, { borderColor: neutral.divider }]}>
+          <Text style={[styles.factorLabel, { color: neutral.textMuted }]}>{label}</Text>
+          <Text style={[styles.factValue, { color: neutral.textPrimary }]}>{value}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const RecordPills = ({ values }: { values: Record<string, unknown> }) => {
+  const { neutral } = useTheme();
+  const entries = Object.entries(values);
+  if (entries.length === 0) {
+    return <Unavailable text="Official totals are not published yet." />;
+  }
+  return (
+    <View style={styles.pillWrap}>
+      {entries.map(([key, value]) => (
+        <View key={key} style={[styles.pill, { backgroundColor: neutral.card, borderColor: neutral.divider }]}>
+          <Text style={[styles.pillText, { color: neutral.textPrimary }]}>
+            {key}: {formatUnknown(value)}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const Unavailable = ({ text }: { text: string }) => {
+  const { neutral } = useTheme();
+  return <Text style={[styles.unavailable, { color: neutral.textMuted }]}>{text}</Text>;
+};
+
+const recordLabel = (record: Record<string, unknown>) => {
+  return (
+    getRecordString(record, 'display_number') ||
+    getRecordString(record, 'version_name') ||
+    getRecordString(record, 'title') ||
+    getRecordString(record, 'name') ||
+    getRecordString(record, 'label') ||
+    getRecordString(record, 'result') ||
+    formatUnknown(record)
+  );
+};
+
+const recordMeta = (record: Record<string, unknown>) => {
+  return (
+    getRecordString(record, 'jurisdiction') ||
+    getRecordString(record, 'version_code') ||
+    getRecordString(record, 'roll_number') ||
+    getRecordString(record, 'source') ||
+    null
+  );
+};
+
+const getRecordString = (record: Record<string, unknown> | null | undefined, key: string) => {
+  const raw = record?.[key];
+  return typeof raw === 'string' ? raw : null;
+};
+
+const formatUnknown = (value: unknown): string => {
+  if (value === null || value === undefined) return 'Unavailable';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) return `${value.length} item${value.length === 1 ? '' : 's'}`;
+  if (typeof value === 'object') return Object.entries(value).map(([key, child]) => `${key}: ${formatUnknown(child)}`).join(', ');
+  return String(value);
+};
+
+const billStatusStep = (status: string) => {
+  const lower = status.toLowerCase();
+  if (lower.includes('law') || lower.includes('signed') || lower.includes('veto')) return 6;
+  if (lower.includes('president')) return 5;
+  if (lower.includes('conference')) return 4;
+  if (lower.includes('senate') || lower.includes('other chamber')) return 3;
+  if (lower.includes('passed') || lower.includes('floor')) return 2;
+  if (lower.includes('committee')) return 1;
+  return 0;
 };
 
 const styles = StyleSheet.create({
@@ -242,140 +569,224 @@ const styles = StyleSheet.create({
     paddingBottom: 12,
     borderBottomWidth: 1,
   },
-  backButton: {
+  iconButton: {
     padding: 8,
-    marginLeft: -8,
   },
   headerActions: {
     flexDirection: 'row',
-    alignItems: 'center',
     gap: 8,
-  },
-  headerButton: {
-    padding: 8,
   },
   scrollView: {
     flex: 1,
   },
   scrollContent: {
     padding: 16,
-    paddingBottom: 100,
-    gap: 20,
+    paddingBottom: 120,
+    gap: 16,
   },
-  branchRow: {
+  kickerRow: {
     flexDirection: 'row',
-  },
-  branchBadge: {
-    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
     alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 20,
-    gap: 6,
   },
-  branchText: {
+  kicker: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  kickerText: {
     fontSize: 12,
-    fontWeight: '700',
-    letterSpacing: 0.5,
+    fontWeight: '800',
+  },
+  dateText: {
+    fontSize: 12,
   },
   headline: {
-    fontSize: 26,
+    fontSize: 27,
     fontWeight: '800',
     lineHeight: 34,
   },
-  metaRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  source: {
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 0.5,
-  },
-  metaDot: {
-    fontSize: 12,
-  },
-  date: {
-    fontSize: 12,
-  },
-  statusSection: {
-    gap: 12,
-  },
-  sectionLabel: {
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.5,
-  },
-  summarySection: {
-    gap: 12,
-  },
   summary: {
     fontSize: 16,
-    lineHeight: 26,
+    lineHeight: 24,
   },
-  tagsSection: {
-    gap: 12,
+  detailStack: {
+    gap: 14,
   },
-  tagsContainer: {
+  section: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    gap: 10,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  bodyText: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  bodyTextStrong: {
+    fontSize: 15,
+    lineHeight: 21,
+    fontWeight: '700',
+  },
+  metaText: {
+    fontSize: 12,
+    lineHeight: 17,
+  },
+  linkText: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  sourceLink: {
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: 10,
+    flexWrap: 'wrap',
+  },
+  primaryButton: {
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '800',
+    fontSize: 13,
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    fontWeight: '800',
+    fontSize: 13,
+  },
+  factorGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 8,
   },
-  tag: {
-    paddingHorizontal: 14,
+  factor: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 8,
+    minWidth: 110,
+    flex: 1,
+  },
+  factorLabel: {
+    fontSize: 11,
+    textTransform: 'capitalize',
+  },
+  factorValue: {
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  positionGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  positionButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 11,
     paddingVertical: 8,
-    borderRadius: 20,
   },
-  tagText: {
-    fontSize: 14,
-    fontWeight: '500',
+  positionText: {
+    fontSize: 13,
+    fontWeight: '800',
   },
-  timelineSection: {
-    gap: 12,
-  },
-  timelineItem: {
-    paddingLeft: 16,
+  timelineRow: {
     borderLeftWidth: 3,
+    paddingLeft: 10,
     gap: 4,
   },
-  timelineDate: {
-    fontSize: 12,
-    fontWeight: '600',
+  recordRow: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 10,
+    gap: 4,
   },
-  timelineEvent: {
+  factGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  fact: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 8,
+    minWidth: 130,
+    flex: 1,
+  },
+  factValue: {
     fontSize: 15,
-    fontWeight: '500',
+    fontWeight: '800',
   },
-  actionsSection: {
+  pillWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  pill: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+  },
+  pillText: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  searchInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+  },
+  positionRow: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 10,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     gap: 12,
-    paddingTop: 8,
   },
-  primaryButton: {
+  positionTextBlock: {
+    flex: 1,
+  },
+  voteBadge: {
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  notice: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
     flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 16,
-    borderRadius: 16,
     gap: 8,
-  },
-  primaryButtonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  secondaryButton: {
-    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 16,
-    borderRadius: 16,
-    borderWidth: 2,
-    gap: 8,
   },
-  secondaryButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
+  unavailable: {
+    fontSize: 14,
+    lineHeight: 20,
   },
 });
 

--- a/frontend/src/features/you/screens/YouScreen.tsx
+++ b/frontend/src/features/you/screens/YouScreen.tsx
@@ -1,354 +1,380 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
-  Alert,
+  ActivityIndicator,
   Pressable,
   ScrollView,
   StyleSheet,
-  Switch,
   Text,
+  TextInput,
   View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { useTheme } from '@theme/ThemeProvider';
-import { useSavedItems } from '../../../context/SavedItemsContext';
-import { useUserPreferences } from '../../../context/UserPreferencesContext';
+import { useFeed } from '@features/feed/hooks/useFeed';
 import { FeedItem } from '@features/feed/types';
+import { CurrentMember } from '@features/members/types';
+import { useDistrictLookup } from '@features/members/hooks/useDistrictLookup';
+import { useUserPreferences } from '@context/UserPreferencesContext';
 import { RootStackParamList } from '@navigation/RootNavigator';
+import { useTheme } from '@theme/ThemeProvider';
 import dayjs from '@utils/dayjs';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
-const interestLabels: Record<string, string> = {
-  legislative: 'Congress',
-  judicial: 'Courts',
-  executive: 'Executive',
-  budget: 'Budget',
-  oversight: 'Oversight',
-};
+const defaultTopics = ['budget', 'oversight', 'health', 'technology', 'veterans'];
 
 const YouScreen = () => {
-  const { neutral, branch: branchColors, semantic, spacing } = useTheme();
+  const { neutral, branch: branchColors, semantic } = useTheme();
   const navigation = useNavigation<NavigationProp>();
-  const { savedItems, clearAll } = useSavedItems();
   const {
     preferences,
-    setNotificationPreferences,
-    resetOnboarding,
+    followMember,
+    unfollowMember,
+    followBill,
+    unfollowBill,
+    followTopic,
+    unfollowTopic,
+    followCommittee,
+    unfollowCommittee,
+    clearDistrictMemberMapping,
   } = useUserPreferences();
+  const { resolve, isLoading: lookupLoading, error: lookupError } = useDistrictLookup();
+  const [lookupText, setLookupText] = useState('');
 
-  const handleItemPress = useCallback((item: FeedItem) => {
-    navigation.navigate('UpdateDetail', { item });
-  }, [navigation]);
-
-  const handleEditInterests = useCallback(() => {
-    navigation.navigate('Onboarding');
-  }, [navigation]);
-
-  const handleNotificationSettings = useCallback(() => {
-    navigation.navigate('NotificationSettings');
-  }, [navigation]);
-
-  const handleClearSaved = useCallback(() => {
-    Alert.alert(
-      'Clear All Saved Items',
-      'Are you sure you want to remove all saved items? This cannot be undone.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        { text: 'Clear All', style: 'destructive', onPress: clearAll },
-      ]
-    );
-  }, [clearAll]);
-
-  const followingCount = {
-    bills: preferences.followedBills.length,
-    members: preferences.followedMembers.length,
-    topics: preferences.followedTopics.length,
-  };
   const districtLabel = preferences.homeDistrict?.state && preferences.homeDistrict?.district
     ? `${preferences.homeDistrict.state}-${preferences.homeDistrict.district}`
     : null;
+
+  const feedOptions = useMemo(() => ({
+    followedBills: preferences.followedBills,
+    followedMembers: preferences.followedMembers,
+    followedTopics: preferences.followedTopics,
+    state: preferences.homeDistrict?.state,
+    district: preferences.homeDistrict?.district,
+    limit: 12,
+  }), [
+    preferences.followedBills,
+    preferences.followedMembers,
+    preferences.followedTopics,
+    preferences.homeDistrict?.state,
+    preferences.homeDistrict?.district,
+  ]);
+  const { items, loading: feedLoading, reload } = useFeed('myGovernment', feedOptions);
+
+  const followedCommittees = preferences.followedCommittees ?? [];
+  const followedMembers = new Set(preferences.followedMembers);
+  const followedBills = new Set(preferences.followedBills);
+  const followedTopics = new Set(preferences.followedTopics);
   const representative = preferences.currentMembers.find(member => member.chamber === 'House');
   const senators = preferences.currentMembers.filter(member => member.chamber === 'Senate');
+
+  const committees = useMemo(() => collectCommittees(items), [items]);
+  const bills = useMemo(() => collectBills(items), [items]);
+  const topics = useMemo(() => Array.from(new Set([...defaultTopics, ...preferences.interests, ...preferences.followedTopics])), [
+    preferences.interests,
+    preferences.followedTopics,
+  ]);
+
+  const handleLookup = useCallback(async () => {
+    const query = lookupText.trim();
+    if (!query) return;
+    const isZip = /^\d{5}$/.test(query);
+    await resolve(isZip ? { zipCode: query } : { address: query });
+  }, [lookupText, resolve]);
+
+  const openItem = useCallback((item: FeedItem) => {
+    navigation.navigate('UpdateDetail', { item });
+  }, [navigation]);
 
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: neutral.background }]}
       contentContainerStyle={styles.scrollContent}
     >
-      {/* Header */}
       <View style={styles.header}>
-        <Text style={[styles.headerTitle, { color: neutral.textPrimary }]}>
-          Your Briefing
+        <Text style={[styles.eyebrow, { color: neutral.textMuted }]}>MY GOVERNMENT</Text>
+        <Text style={[styles.title, { color: neutral.textPrimary }]}>
+          {districtLabel ?? 'Add Your District'}
         </Text>
       </View>
 
-      {/* Following Summary */}
-      <View style={[styles.section, { backgroundColor: neutral.card }]}>
-        <View style={styles.sectionHeader}>
-          <Ionicons name="bookmark" size={20} color={branchColors.agency} />
-          <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>
-            Following
+      <View style={[styles.panel, { backgroundColor: neutral.card, borderColor: neutral.divider }]}>
+        <View style={styles.lookupRow}>
+          <TextInput
+            value={lookupText}
+            onChangeText={setLookupText}
+            placeholder="ZIP or address"
+            placeholderTextColor={neutral.textMuted}
+            style={[styles.lookupInput, { color: neutral.textPrimary, borderColor: neutral.divider }]}
+            autoCapitalize="words"
+            returnKeyType="search"
+            onSubmitEditing={handleLookup}
+          />
+          <Pressable
+            style={[styles.lookupButton, { backgroundColor: branchColors.agency }]}
+            onPress={handleLookup}
+            disabled={lookupLoading}
+          >
+            {lookupLoading ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Ionicons name="search" size={18} color="#FFFFFF" />
+            )}
+          </Pressable>
+        </View>
+        {lookupError && <Text style={[styles.warningText, { color: semantic.error }]}>{lookupError}</Text>}
+        {preferences.districtLookupAmbiguity && (
+          <Text style={[styles.warningText, { color: semantic.warning }]}>
+            {preferences.districtLookupAmbiguity}
           </Text>
-        </View>
-        <View style={styles.followingRow}>
-          <View style={styles.followingStat}>
-            <Text style={[styles.followingNumber, { color: branchColors.legislative }]}>
-              {followingCount.bills}
-            </Text>
-            <Text style={[styles.followingLabel, { color: neutral.textMuted }]}>Bills</Text>
-          </View>
-          <View style={[styles.followingDivider, { backgroundColor: neutral.divider }]} />
-          <View style={styles.followingStat}>
-            <Text style={[styles.followingNumber, { color: branchColors.executive }]}>
-              {followingCount.members}
-            </Text>
-            <Text style={[styles.followingLabel, { color: neutral.textMuted }]}>Members</Text>
-          </View>
-          <View style={[styles.followingDivider, { backgroundColor: neutral.divider }]} />
-          <View style={styles.followingStat}>
-            <Text style={[styles.followingNumber, { color: branchColors.judicial }]}>
-              {followingCount.topics}
-            </Text>
-            <Text style={[styles.followingLabel, { color: neutral.textMuted }]}>Topics</Text>
-          </View>
-        </View>
+        )}
+        {preferences.homeDistrict && (
+          <Pressable onPress={clearDistrictMemberMapping}>
+            <Text style={[styles.linkText, { color: branchColors.agency }]}>Clear district mapping</Text>
+          </Pressable>
+        )}
       </View>
 
-      {/* My Government */}
-      <View style={[styles.section, { backgroundColor: neutral.card }]}>
-        <View style={styles.sectionHeader}>
-          <Ionicons name="business" size={20} color={branchColors.legislative} />
-          <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>
-            My Government
-          </Text>
-          {districtLabel && (
-            <Text style={[styles.districtBadge, { color: branchColors.legislative, backgroundColor: neutral.surface }]}>
-              {districtLabel}
-            </Text>
-          )}
-        </View>
-
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>Representatives</Text>
         {!preferences.homeDistrict ? (
-          <View style={styles.emptyState}>
-            <Ionicons name="location-outline" size={32} color={neutral.textMuted} />
-            <Text style={[styles.emptyText, { color: neutral.textSecondary }]}>
-              Add a district lookup to show your representative and senators here.
-            </Text>
-          </View>
+          <EmptyMessage text="Resolve a district to show your representative and senators." />
         ) : (
-          <View style={styles.memberList}>
-            {preferences.districtLookupAmbiguity && (
-              <Text style={[styles.lookupWarning, { color: semantic.warning }]}>
-                {preferences.districtLookupAmbiguity}
-              </Text>
-            )}
+          <View style={styles.stack}>
             {representative && (
-              <View style={[styles.memberRow, { borderBottomColor: neutral.divider }]}>
-                <View style={styles.memberInfo}>
-                  <Text style={[styles.memberRole, { color: neutral.textMuted }]}>Representative</Text>
-                  <Text style={[styles.memberName, { color: neutral.textPrimary }]}>
-                    {representative.name}
-                  </Text>
-                </View>
-                <Text style={[styles.memberParty, { color: neutral.textMuted }]}>
-                  {representative.party ?? ''}
-                </Text>
-              </View>
+              <MemberRow
+                member={representative}
+                label="Representative"
+                followed={followedMembers.has(representative.bioguide_id)}
+                onToggle={() => followedMembers.has(representative.bioguide_id)
+                  ? unfollowMember(representative.bioguide_id)
+                  : followMember(representative.bioguide_id)}
+              />
             )}
             {senators.map(senator => (
-              <View key={senator.bioguide_id} style={[styles.memberRow, { borderBottomColor: neutral.divider }]}>
-                <View style={styles.memberInfo}>
-                  <Text style={[styles.memberRole, { color: neutral.textMuted }]}>Senator</Text>
-                  <Text style={[styles.memberName, { color: neutral.textPrimary }]}>
-                    {senator.name}
-                  </Text>
-                </View>
-                <Text style={[styles.memberParty, { color: neutral.textMuted }]}>
-                  {senator.party ?? ''}
-                </Text>
-              </View>
+              <MemberRow
+                key={senator.bioguide_id}
+                member={senator}
+                label="Senator"
+                followed={followedMembers.has(senator.bioguide_id)}
+                onToggle={() => followedMembers.has(senator.bioguide_id)
+                  ? unfollowMember(senator.bioguide_id)
+                  : followMember(senator.bioguide_id)}
+              />
             ))}
             {preferences.currentMembers.length === 0 && (
-              <Text style={[styles.emptyText, { color: neutral.textSecondary }]}>
-                No current members are loaded for this district yet.
-              </Text>
+              <EmptyMessage text="No current members are loaded for this district yet." />
             )}
           </View>
         )}
       </View>
 
-      {/* Saved Items */}
-      <View style={[styles.section, { backgroundColor: neutral.card }]}>
-        <View style={styles.sectionHeader}>
-          <Ionicons name="star" size={20} color={branchColors.agency} />
-          <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>
-            Saved Items
-          </Text>
-          {savedItems.length > 0 && (
-            <Pressable onPress={handleClearSaved} style={styles.clearButton}>
-              <Text style={[styles.clearButtonText, { color: semantic.error }]}>Clear All</Text>
-            </Pressable>
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>Followed Topics</Text>
+        <View style={styles.chipWrap}>
+          {topics.map(topic => {
+            const active = followedTopics.has(topic);
+            return (
+              <Pressable
+                key={topic}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: active ? branchColors.agency : neutral.card,
+                    borderColor: active ? branchColors.agency : neutral.divider,
+                  },
+                ]}
+                onPress={() => active ? unfollowTopic(topic) : followTopic(topic)}
+              >
+                <Text style={[styles.chipText, { color: active ? '#FFFFFF' : neutral.textPrimary }]}>
+                  {topic}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>Bills And Committees</Text>
+        <View style={styles.stack}>
+          {bills.map(bill => {
+            const billId = bill.canonicalId;
+            const active = followedBills.has(billId);
+            return (
+              <FollowRow
+                key={billId}
+                label={bill.label}
+                meta={bill.title}
+                followed={active}
+                onToggle={() => active ? unfollowBill(billId) : followBill(billId)}
+              />
+            );
+          })}
+          {committees.map(committee => {
+            const active = followedCommittees.includes(committee.id);
+            return (
+              <FollowRow
+                key={committee.id}
+                label={committee.name}
+                meta={committee.jurisdiction ?? 'Committee'}
+                followed={active}
+                onToggle={() => active ? unfollowCommittee(committee.id) : followCommittee(committee.id)}
+              />
+            );
+          })}
+          {bills.length === 0 && committees.length === 0 && (
+            <EmptyMessage text="Ranked feed cards will surface followable bills and committees here." />
           )}
         </View>
+      </View>
 
-        {savedItems.length === 0 ? (
-          <View style={styles.emptyState}>
-            <Ionicons name="bookmark-outline" size={32} color={neutral.textMuted} />
-            <Text style={[styles.emptyText, { color: neutral.textSecondary }]}>
-              No saved items yet. Tap the bookmark icon on any update to save it here.
-            </Text>
+      <View style={styles.section}>
+        <View style={styles.sectionHeadingRow}>
+          <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>Recent Local Activity</Text>
+          <Pressable onPress={reload}>
+            <Ionicons name="refresh" size={18} color={branchColors.agency} />
+          </Pressable>
+        </View>
+        {feedLoading && items.length === 0 ? (
+          <View style={styles.inlineLoader}>
+            <ActivityIndicator color={branchColors.agency} />
           </View>
         ) : (
-          <View style={styles.savedList}>
-            {savedItems.slice(0, 5).map(item => (
+          <View style={styles.stack}>
+            {items.slice(0, 8).map(item => (
               <Pressable
                 key={item.id}
-                style={[styles.savedItem, { borderBottomColor: neutral.divider }]}
-                onPress={() => handleItemPress(item)}
+                style={[styles.activityRow, { backgroundColor: neutral.card, borderColor: neutral.divider }]}
+                onPress={() => openItem(item)}
               >
-                <View style={[styles.savedItemBar, { backgroundColor: branchColors[item.branch] || branchColors.legislative }]} />
-                <View style={styles.savedItemContent}>
-                  <Text style={[styles.savedItemHeadline, { color: neutral.textPrimary }]} numberOfLines={2}>
-                    {item.headline}
-                  </Text>
-                  <Text style={[styles.savedItemMeta, { color: neutral.textMuted }]}>
-                    {item.branch.toUpperCase()} • {dayjs(item.published_at).fromNow()}
-                  </Text>
-                </View>
-                <Ionicons name="chevron-forward" size={20} color={neutral.textMuted} />
+                <Text style={[styles.activityType, { color: branchColors[item.branch] ?? branchColors.legislative }]}>
+                  {(item.card_type ?? item.branch).toUpperCase()}
+                </Text>
+                <Text style={[styles.activityHeadline, { color: neutral.textPrimary }]} numberOfLines={2}>
+                  {item.headline}
+                </Text>
+                <Text style={[styles.activityMeta, { color: neutral.textMuted }]}>
+                  {dayjs(item.published_at).fromNow()}
+                </Text>
               </Pressable>
             ))}
-            {savedItems.length > 5 && (
-              <Text style={[styles.moreItemsText, { color: neutral.textMuted }]}>
-                +{savedItems.length - 5} more items
-              </Text>
+            {items.length === 0 && (
+              <EmptyMessage text="No recent activity matches your district or followed objects yet." />
             )}
           </View>
         )}
-      </View>
-
-      {/* Notifications */}
-      <View style={[styles.section, { backgroundColor: neutral.card }]}>
-        <View style={styles.sectionHeader}>
-          <Ionicons name="notifications" size={20} color={branchColors.agency} />
-          <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>
-            Notifications
-          </Text>
-        </View>
-
-        <View style={styles.settingsList}>
-          <View style={[styles.settingRow, { borderBottomColor: neutral.divider }]}>
-            <View style={styles.settingInfo}>
-              <Text style={[styles.settingLabel, { color: neutral.textPrimary }]}>Daily Digest</Text>
-              <Text style={[styles.settingDescription, { color: neutral.textMuted }]}>
-                {preferences.notifications.dailyDigestTime}
-              </Text>
-            </View>
-            <Switch
-              value={preferences.notifications.dailyDigest}
-              onValueChange={(value) => setNotificationPreferences({ dailyDigest: value })}
-              trackColor={{ false: neutral.divider, true: branchColors.agency + '80' }}
-              thumbColor={preferences.notifications.dailyDigest ? branchColors.agency : neutral.textMuted}
-            />
-          </View>
-
-          <View style={[styles.settingRow, { borderBottomColor: neutral.divider }]}>
-            <View style={styles.settingInfo}>
-              <Text style={[styles.settingLabel, { color: neutral.textPrimary }]}>Breaking News</Text>
-              <Text style={[styles.settingDescription, { color: neutral.textMuted }]}>
-                Urgent government updates
-              </Text>
-            </View>
-            <Switch
-              value={preferences.notifications.breakingNews}
-              onValueChange={(value) => setNotificationPreferences({ breakingNews: value })}
-              trackColor={{ false: neutral.divider, true: branchColors.agency + '80' }}
-              thumbColor={preferences.notifications.breakingNews ? branchColors.agency : neutral.textMuted}
-            />
-          </View>
-
-          <View style={styles.settingRow}>
-            <View style={styles.settingInfo}>
-              <Text style={[styles.settingLabel, { color: neutral.textPrimary }]}>Bill Updates</Text>
-              <Text style={[styles.settingDescription, { color: neutral.textMuted }]}>
-                Updates on followed bills
-              </Text>
-            </View>
-            <Switch
-              value={preferences.notifications.billUpdates}
-              onValueChange={(value) => setNotificationPreferences({ billUpdates: value })}
-              trackColor={{ false: neutral.divider, true: branchColors.agency + '80' }}
-              thumbColor={preferences.notifications.billUpdates ? branchColors.agency : neutral.textMuted}
-            />
-          </View>
-        </View>
-
-        <Pressable
-          style={[styles.settingsLink, { borderTopColor: neutral.divider }]}
-          onPress={handleNotificationSettings}
-        >
-          <Text style={[styles.settingsLinkText, { color: branchColors.agency }]}>
-            More notification settings
-          </Text>
-          <Ionicons name="chevron-forward" size={20} color={branchColors.agency} />
-        </Pressable>
-      </View>
-
-      {/* Interests */}
-      <View style={[styles.section, { backgroundColor: neutral.card }]}>
-        <View style={styles.sectionHeader}>
-          <Ionicons name="heart" size={20} color={branchColors.agency} />
-          <Text style={[styles.sectionTitle, { color: neutral.textPrimary }]}>
-            Interests
-          </Text>
-        </View>
-
-        <View style={styles.interestsList}>
-          {preferences.interests.length === 0 ? (
-            <Text style={[styles.emptyText, { color: neutral.textSecondary }]}>
-              No interests selected yet.
-            </Text>
-          ) : (
-            <View style={styles.interestChips}>
-              {preferences.interests.map(interest => (
-                <View
-                  key={interest}
-                  style={[styles.interestChip, { backgroundColor: neutral.surface }]}
-                >
-                  <Text style={[styles.interestChipText, { color: neutral.textPrimary }]}>
-                    {interestLabels[interest] || interest}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          )}
-        </View>
-
-        <Pressable
-          style={[styles.settingsLink, { borderTopColor: neutral.divider }]}
-          onPress={handleEditInterests}
-        >
-          <Text style={[styles.settingsLinkText, { color: branchColors.agency }]}>
-            Edit your interests
-          </Text>
-          <Ionicons name="chevron-forward" size={20} color={branchColors.agency} />
-        </Pressable>
-      </View>
-
-      {/* App Info */}
-      <View style={styles.footer}>
-        <Text style={[styles.footerText, { color: neutral.textMuted }]}>
-          Congresscape v0.1.0
-        </Text>
-        <Text style={[styles.footerText, { color: neutral.textMuted }]}>
-          Your daily briefing on federal government activity
-        </Text>
       </View>
     </ScrollView>
   );
+};
+
+const MemberRow = ({
+  member,
+  label,
+  followed,
+  onToggle,
+}: {
+  member: CurrentMember;
+  label: string;
+  followed: boolean;
+  onToggle: () => void;
+}) => (
+  <FollowRow
+    label={member.name}
+    meta={`${label}${member.party ? ` · ${member.party}` : ''}`}
+    followed={followed}
+    onToggle={onToggle}
+  />
+);
+
+const FollowRow = ({
+  label,
+  meta,
+  followed,
+  onToggle,
+}: {
+  label: string;
+  meta?: string | null;
+  followed: boolean;
+  onToggle: () => void;
+}) => {
+  const { neutral, branch } = useTheme();
+  return (
+    <View style={[styles.followRow, { backgroundColor: neutral.card, borderColor: neutral.divider }]}>
+      <View style={styles.followText}>
+        <Text style={[styles.followLabel, { color: neutral.textPrimary }]}>{label}</Text>
+        {meta && <Text style={[styles.followMeta, { color: neutral.textMuted }]}>{meta}</Text>}
+      </View>
+      <Pressable
+        style={[
+          styles.followButton,
+          {
+            borderColor: branch.agency,
+            backgroundColor: followed ? branch.agency : 'transparent',
+          },
+        ]}
+        onPress={onToggle}
+      >
+        <Text style={[styles.followButtonText, { color: followed ? '#FFFFFF' : branch.agency }]}>
+          {followed ? 'Following' : 'Follow'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const EmptyMessage = ({ text }: { text: string }) => {
+  const { neutral } = useTheme();
+  return (
+    <View style={styles.emptyBox}>
+      <Text style={[styles.emptyText, { color: neutral.textSecondary }]}>{text}</Text>
+    </View>
+  );
+};
+
+const collectBills = (items: FeedItem[]) => {
+  const byId = new Map<string, { canonicalId: string; label: string; title?: string | null }>();
+  items.forEach(item => {
+    const bill = item.detail?.bill;
+    if (!bill) return;
+    byId.set(bill.canonical_id, {
+      canonicalId: bill.canonical_id,
+      label: bill.display_number,
+      title: bill.short_title ?? bill.title,
+    });
+  });
+  return Array.from(byId.values());
+};
+
+const collectCommittees = (items: FeedItem[]) => {
+  const byId = new Map<string, { id: string; name: string; jurisdiction?: string | null }>();
+  items.forEach(item => {
+    const billCommittees = item.detail?.bill?.committees ?? [];
+    billCommittees.forEach(committee => {
+      const id = getString(committee, 'committee_code');
+      const name = getString(committee, 'name');
+      if (id && name) {
+        byId.set(id, { id, name, jurisdiction: getString(committee, 'jurisdiction') });
+      }
+    });
+    const hearingCommittee = item.detail?.hearing?.committee;
+    if (hearingCommittee) {
+      const id = getString(hearingCommittee, 'committee_code');
+      const name = getString(hearingCommittee, 'name');
+      if (id && name) {
+        byId.set(id, { id, name, jurisdiction: getString(hearingCommittee, 'jurisdiction') });
+      }
+    }
+  });
+  return Array.from(byId.values());
+};
+
+const getString = (value: Record<string, unknown>, key: string) => {
+  const raw = value[key];
+  return typeof raw === 'string' ? raw : null;
 };
 
 const styles = StyleSheet.create({
@@ -358,198 +384,141 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingTop: 60,
     paddingHorizontal: 16,
-    paddingBottom: 100,
-    gap: 16,
+    paddingBottom: 120,
+    gap: 18,
   },
   header: {
-    paddingVertical: 8,
+    gap: 4,
   },
-  headerTitle: {
-    fontSize: 28,
+  eyebrow: {
+    fontSize: 12,
     fontWeight: '800',
   },
-  section: {
-    borderRadius: 20,
-    padding: 16,
-    gap: 16,
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
   },
-  sectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
+  panel: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
     gap: 10,
   },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    flex: 1,
-  },
-  clearButton: {
-    padding: 4,
-  },
-  clearButtonText: {
-    fontSize: 14,
-    fontWeight: '500',
-  },
-  followingRow: {
+  lookupRow: {
     flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-around',
-    paddingVertical: 8,
+    gap: 8,
   },
-  followingStat: {
-    alignItems: 'center',
-    gap: 4,
+  lookupInput: {
     flex: 1,
-  },
-  followingNumber: {
-    fontSize: 28,
-    fontWeight: '700',
-  },
-  followingLabel: {
-    fontSize: 12,
-    fontWeight: '500',
-  },
-  followingDivider: {
-    width: 1,
-    height: 40,
-  },
-  districtBadge: {
-    fontSize: 13,
-    fontWeight: '700',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 12,
-  },
-  memberList: {
-    gap: 0,
-  },
-  memberRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
     paddingVertical: 10,
-    borderBottomWidth: 1,
-    gap: 12,
-  },
-  memberInfo: {
-    flex: 1,
-    gap: 2,
-  },
-  memberRole: {
-    fontSize: 12,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-  },
-  memberName: {
     fontSize: 15,
-    fontWeight: '600',
   },
-  memberParty: {
-    fontSize: 13,
-    fontWeight: '500',
+  lookupButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  lookupWarning: {
+  warningText: {
     fontSize: 13,
     lineHeight: 18,
   },
-  emptyState: {
-    alignItems: 'center',
-    gap: 12,
-    paddingVertical: 20,
-  },
-  emptyText: {
-    fontSize: 14,
-    textAlign: 'center',
-    lineHeight: 20,
-  },
-  savedList: {
-    gap: 0,
-  },
-  savedItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    gap: 12,
-  },
-  savedItemBar: {
-    width: 3,
-    height: 40,
-    borderRadius: 2,
-  },
-  savedItemContent: {
-    flex: 1,
-    gap: 4,
-  },
-  savedItemHeadline: {
-    fontSize: 15,
-    fontWeight: '500',
-    lineHeight: 20,
-  },
-  savedItemMeta: {
-    fontSize: 12,
-  },
-  moreItemsText: {
-    fontSize: 14,
-    textAlign: 'center',
-    paddingTop: 12,
-  },
-  settingsList: {
-    gap: 0,
-  },
-  settingRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-  },
-  settingInfo: {
-    flex: 1,
-    gap: 2,
-  },
-  settingLabel: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  settingDescription: {
+  linkText: {
     fontSize: 13,
+    fontWeight: '700',
   },
-  settingsLink: {
+  section: {
+    gap: 10,
+  },
+  sectionHeadingRow: {
     flexDirection: 'row',
-    alignItems: 'center',
     justifyContent: 'space-between',
-    paddingTop: 12,
-    borderTopWidth: 1,
+    alignItems: 'center',
   },
-  settingsLinkText: {
-    fontSize: 15,
-    fontWeight: '500',
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '800',
   },
-  interestsList: {
+  stack: {
     gap: 8,
   },
-  interestChips: {
+  followRow: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+  },
+  followText: {
+    flex: 1,
+    gap: 3,
+  },
+  followLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  followMeta: {
+    fontSize: 12,
+  },
+  followButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  followButtonText: {
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  chipWrap: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 8,
   },
-  interestChip: {
-    paddingHorizontal: 14,
+  chip: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
     paddingVertical: 8,
-    borderRadius: 20,
   },
-  interestChipText: {
-    fontSize: 14,
-    fontWeight: '500',
+  chipText: {
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'capitalize',
   },
-  footer: {
-    alignItems: 'center',
-    gap: 4,
-    paddingVertical: 20,
+  activityRow: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    gap: 5,
   },
-  footerText: {
+  activityType: {
+    fontSize: 11,
+    fontWeight: '800',
+  },
+  activityHeadline: {
+    fontSize: 15,
+    lineHeight: 20,
+    fontWeight: '700',
+  },
+  activityMeta: {
     fontSize: 12,
+  },
+  inlineLoader: {
+    paddingVertical: 24,
+  },
+  emptyBox: {
+    paddingVertical: 14,
+  },
+  emptyText: {
+    fontSize: 14,
+    lineHeight: 20,
   },
 });
 

--- a/frontend/src/navigation/MainTabNavigator.tsx
+++ b/frontend/src/navigation/MainTabNavigator.tsx
@@ -72,8 +72,9 @@ const MainTabNavigator = () => {
         name="You"
         component={YouScreen}
         options={{
+          title: 'My Gov',
           tabBarIcon: ({ color, size }) => (
-            <Ionicons name="person" size={size} color={color} />
+            <Ionicons name="business" size={size} color={color} />
           ),
         }}
       />

--- a/frontend/src/services/updatesService.ts
+++ b/frontend/src/services/updatesService.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import dayjs from 'dayjs';
 import Constants from 'expo-constants';
 
 // Fallback to localhost if not configured (e.g. in development)

--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -1,6 +1,5 @@
 import React, { PropsWithChildren, createContext, useContext, useMemo } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { useColorScheme } from 'react-native';
 
 import {
   branchPalette,
@@ -24,7 +23,6 @@ type Theme = {
 const ThemeContext = createContext<Theme | undefined>(undefined);
 
 export const ThemeProvider = ({ children }: PropsWithChildren) => {
-  const system = useColorScheme();
   const value = useMemo<Theme>(() => ({
     branch: branchPalette,
     neutral: neutralPalette,
@@ -33,7 +31,7 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     spacing,
     borderRadius,
     isDark: true // Default to dark mode aesthetic
-  }), [system]);
+  }), []);
 
   return (
     <ThemeContext.Provider value={value}>


### PR DESCRIPTION
## Summary

Completes the Primary-Source Civic Feed M2 milestone across CON-12 through CON-16:

- Adds source-transparent Today feed ranking from canonical primary-source bill, vote, and hearing events.
- Extends feed responses with enriched card metadata, source trails, rank context, and detail payloads.
- Reworks Today into a ranked primary-source surface with vote, hearing, and bill sections.
- Reworks the You tab into My Government with district lookup, follows, topics, committees, and local activity.
- Adds structured bill lifecycle, vote detail, and hearing detail rendering.
- Adds local bill-position preference state used by bill detail and referenced for M3 follow-up work.
- Fixes the repo quality gate by adding the frontend ESLint toolchain/config and cleaning lint/Pydantic warnings.

## Linear

- CON-12: Today feed ranking from primary-source events
- CON-13: My Government surface
- CON-14: Bill lifecycle detail view
- CON-15: Vote detail view
- CON-16: Hearing detail view

M2 has already been marked complete in Linear with per-issue completion notes. CON-17, CON-18, and CON-20 were updated with references to the local bill-position state introduced here.

## Verification

- `npm run quality`
  - backend pytest: `12 passed`
  - backend Ruff: passed
  - frontend TypeScript: passed
  - frontend ESLint: passed
- `git diff --check`: passed
- Browser smoke was run before commit for Today, My Government, vote detail, hearing detail, bill detail, and bill position selection.